### PR TITLE
Add env filename for .env.stage

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -932,6 +932,7 @@ export const fileIcons: FileIcons = {
         '.env.dist',
         '.env.prod',
         '.env.production',
+        '.env.stage',
         '.env.staging',
         '.env.preview',
         '.env.test',


### PR DESCRIPTION
Please consider adding an additional filename to the array for .env files in 'stage'.  Looks like it was just a miss and probably intended to be included.  Please let me know if you would like an issue opened as well.  Thank you!