### PR TITLE
Add Resolver folder icon (Closes #1295)

### DIFF
--- a/icons/folder-resolver-open.svg
+++ b/icons/folder-resolver-open.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414" version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><path d="M19 20H4a2 2 0 0 1-2-2V6c0-1.11.89-2 2-2h6l2 2h7c1.097 0 2 .903 2 2H4v10l2.14-8h17.07l-2.28 8.5c-.23.87-1.01 1.5-1.93 1.5z" fill="#43a047"/><path d="m21.999 10.665-5.8931 5.893-2.6099-2.6098-1.9045 1.9045 4.5144 4.9247 7.7976-7.7975z" fill="#c8e6c9" stroke-width="1.6416"/></svg>

--- a/icons/folder-resolver.svg
+++ b/icons/folder-resolver.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414" version="1.1" viewBox="0 0 24 24" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><path d="M10 4H4c-1.11 0-2 .89-2 2v12c0 1.097.903 2 2 2h16c1.097 0 2-.903 2-2V8a2 2 0 0 0-2-2h-8l-2-2z" fill="#43a047" fill-rule="nonzero"/><path d="m21.999 10.665-5.893 5.893-2.6098-2.6098-1.9045 1.9045 4.5143 4.9247 7.7975-7.7975z" fill="#c8e6c9" stroke-width="1.6416"/></svg>

--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -673,6 +673,10 @@ export const folderIcons: FolderTheme[] = [
         name: 'folder-java',
         folderNames: ['java'],
       },
+      {
+        name: 'folder-resolver',
+        folderNames: ['resolver', 'resolvers'],
+      },
     ],
   },
   {


### PR DESCRIPTION
Preview:

<table>
<thead>
<tr>
<th>
Collapsed folder
</th>
<th>
Expanded folder
</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/12248527/138322439-cc938e6e-3229-4eeb-af6e-10479d341378.png" alt="collapsed resolver folder icon" width="200px"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/12248527/138322556-bb9a0530-5eb8-4d1e-bc6e-4cada23cc11c.png" alt="collapsed resolver folder icon" width="200px"/>
</td>
</tr>
</thead>
</table>