### PR TITLE
chore: husky config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+npm run check

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,3 @@
+{
+  "**/*.svg": "npx svg-color-linter --colors ./material-colors.yml"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "glob": "^7.2.0",
+        "husky": "^8.0.1",
         "mocha": "^9.1.3",
         "prettier": "^2.5.0",
         "puppeteer": "^11.0.0",
@@ -2175,6 +2176,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ieee754": {
@@ -5838,6 +5854,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "changelog": "changelog-machine --config changelog.config.json",
     "preversion": "npm run contributors && git add images/contributors.png && npm run preview && git add images/fileIcons.png && git add images/folderIcons.png",
     "version": "npm run changelog && git add CHANGELOG.md",
-    "vscode:prepublish": "npm run lint && npm run compile && npm run package-web"
+    "vscode:prepublish": "npm run lint && npm run compile && npm run package-web",
+    "prepare": "husky install"
   },
   "publisher": "PKief",
   "author": {
@@ -249,6 +250,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "glob": "^7.2.0",
+    "husky": "^8.0.1",
     "mocha": "^9.1.3",
     "prettier": "^2.5.0",
     "puppeteer": "^11.0.0",


### PR DESCRIPTION
This PR introduces the husky's config to validate the colors of changed icons locally.
This will catch errors regarding the colors of icons before putting them into the repo.
That way we won't have to wait for CI to find the problem.