### PR TITLE
feat: add toml icon

### DIFF
--- a/icons/toml.svg
+++ b/icons/toml.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path fill="#cfd8dc" d="M4 6V4h8v2H9v7H7V6z"/><path fill="#ef5350" d="M4 1v1H2v12h2v1H1V1zM12 1v1h2v12h-2v1h3V1z"/></svg>

--- a/icons/toml_light.svg
+++ b/icons/toml_light.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><path d="M4 6V4h8v2H9v7H7V6z" fill="#455a64"/><path d="M4 1v1H2v12h2v1H1V1zM12 1v1h2v12h-2v1h3V1z" fill="#ef5350"/></svg>

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -102,6 +102,7 @@ export const fileIcons: FileIcons = {
       ],
       fileNames: ['.htaccess'],
     },
+    { name: 'toml', fileExtensions: ['toml'], light: true },
     {
       name: 'image',
       fileExtensions: [
@@ -295,7 +296,6 @@ export const fileIcons: FileIcons = {
         'settings',
         'option',
         'props',
-        'toml',
         'prefs',
         'sln.dotsettings',
         'sln.dotsettings.user',

--- a/src/core/icons/languageIcons.ts
+++ b/src/core/icons/languageIcons.ts
@@ -17,8 +17,9 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'matlab' }, ids: ['matlab'] },
   {
     icon: { name: 'settings' },
-    ids: ['makefile', 'toml', 'ini', 'properties', 'spring-boot-properties'],
+    ids: ['makefile', 'ini', 'properties', 'spring-boot-properties'],
   },
+  { icon: { name: 'toml', light: true }, ids: ['toml'] },
   { icon: { name: 'shaderlab' }, ids: ['shaderlab'] },
   { icon: { name: 'diff' }, ids: ['diff'] },
   { icon: { name: 'json' }, ids: ['json', 'jsonc', 'json5'] },


### PR DESCRIPTION
Icon from: <https://toml.io>

I think it might be necessary to change the color of that black `T` in the middle (to a lighter gray? maybe) to fit dark backgrounds.

This pr resolves #361 and is related to #362