### PR TITLE
feat: add cypress 10.0.0 test file extensions

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2058,6 +2058,10 @@ export const fileIcons: FileIcons = {
         'cypress.config.js',
         'cypress.config.cjs',
         'cypress.config.mjs',
+        '.cy.js',
+        '.cy.jsx',
+        '.cy.ts',
+        '.cy.tsx'
       ],
     },
     { name: 'siyuan', fileExtensions: ['sy'] },

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2058,11 +2058,13 @@ export const fileIcons: FileIcons = {
         'cypress.config.js',
         'cypress.config.cjs',
         'cypress.config.mjs',
+      ],
+      fileExtensions: [
         '.cy.js',
         '.cy.jsx',
         '.cy.ts',
         '.cy.tsx'
-      ],
+      ]
     },
     { name: 'siyuan', fileExtensions: ['sy'] },
     { name: 'ndst', fileExtensions: ['ndst.yml', 'ndst.yaml', 'ndst.json'] },


### PR DESCRIPTION
Add the new cypress 10 test files extensions as mentioned in the docs.

> The e2e.specPattern default value for new projects is cypress/e2e/**.cy.{js,jsx,ts,tsx}. For existing projects, please run cypress open to have your spec files automatically migrated to match this specPattern. Addressed in #21193.

https://docs.cypress.io/guides/references/changelog#10-0-0