### PR TITLE
feat: Expand settings/lib extensions

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -237,9 +237,12 @@ export const fileIcons: FileIcons = {
         'props',
         'toml',
         'prefs',
-        'sln.dotsettings',
-        'sln.dotsettings.user',
+        'dotsettings',
+        'user',
         'cfg',
+        'targets',
+        'o',
+        'so',
       ],
       fileNames: [
         '.jshintignore',
@@ -469,7 +472,7 @@ export const fileIcons: FileIcons = {
         'mrf',
       ],
     },
-    { name: 'lib', fileExtensions: ['lib', 'bib'] },
+    { name: 'lib', fileExtensions: ['lib', 'bib', 'a'] },
     {
       name: 'ruby',
       fileExtensions: ['rb', 'erb', 'rbs'],


### PR DESCRIPTION
- Trim away unnecessary prefixes for `sln.dotsettings` & `sln.dotsettings.user` to just `dotsettings` & `user`, as they're only used in the context of settings and/or storing preferences
- Add `targets` as it fills a very similar role to `props`
- Implement GCC equivalents for `obj/lib/dll` as `o/a/so` respectively. (`obj` can double as a 3d filetype which is why it's part of "3d", but `o` is exclusively an object file so it's part of "settings")