### PR TITLE
Comment on folder icon motive coloring.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,8 +93,7 @@ This uniform color selection makes the folder icons look more consistent and fit
 | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | <img src="./images/how-tos/svg-folder-icon-with-correct-colors.png" width="200px" /> | <img src="./images/how-tos/svg-folder-icon-with-wrong-colors.png" width="200px" /> |
 
-The use of colors for the motive from outside the second row of the Material Design pallete is permissable where the motive duplicates an existing file icon, where the file icon is derived from an existing third party icon. In this case the motive coloring should match that of the corresponding file icon, which must still follow the guidelines specified in
-[Use Material Design colors](#use-material-design-colors), so that colours are not introduced from outside the Material Design pallete unnecessarily.
+The use of colors for the motive from outside the second row of the Material Design pallete is permissable where the motive duplicates an existing file icon, where the file icon is derived from an existing third party icon. In this case the motive coloring should match that of the corresponding file icon, which must still follow the guidelines specified in [Use Material Design colors](#use-material-design-colors), so that colours are not introduced from outside the Material Design pallete unnecessarily.
 
 <h3 id="icon-spacing">Icon spacing</h3>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,9 @@ This uniform color selection makes the folder icons look more consistent and fit
 | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | <img src="./images/how-tos/svg-folder-icon-with-correct-colors.png" width="200px" /> | <img src="./images/how-tos/svg-folder-icon-with-wrong-colors.png" width="200px" /> |
 
+The use of colors for the motive from outside the second row of the Material Design pallete is permissable where the motive duplicates an existing file icon, where the file icon is derived from an existing third party icon. In this case the motive coloring should match that of the corresponding file icon, which must still follow the guidelines specified in
+[Use Material Design colors](#use-material-design-colors), so that colours are not introduced from outside the Material Design pallete unnecessarily.
+
 <h3 id="icon-spacing">Icon spacing</h3>
 
 All icons have a small distance to the edge. This way they don't seem so pressed together and have a little more air. It is not defined how much margin you have to leave them, because this is always a bit different. Just make sure that there is a space to the outside.


### PR DESCRIPTION
The contribution guide states that the color of folder icon motives must be taken from the second row of the Material Design pallete. This second row defines a selection of pastel-like colours.

This rule is clearly violated for motives that are themselves file icons derived from third party icons.
For example, the python folder icons folder-python.svg and folder-python-open.svg utilise the bold yellow #fdd835 and blue #3c78aa.

Added a coment to the contribution guide to reflect this. This PR adds a single line of documentation.