### PR TITLE
Add `.fastlane` to fastlane folder icons

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -459,7 +459,7 @@ export const folderIcons: FolderTheme[] = [
       },
       { name: 'folder-moon', folderNames: ['.moon'] },
       { name: 'folder-debug', folderNames: ['debug', 'debugging'] },
-      { name: 'folder-fastlane', folderNames: ['fastlane'] },
+      { name: 'folder-fastlane', folderNames: ['fastlane', '.fastlane'] },
       {
         name: 'folder-plugin',
         folderNames: [


### PR DESCRIPTION
Add the `.fastlane` folder because it is referenced the same way as the `fastlane` folder.

https://github.com/fastlane/fastlane/blob/9ae433c617a13c0801a9b45f2cf7f8139fbdb427/credentials_manager/lib/credentials_manager/appfile_config.rb#L19

```rb
    def self.default_path
      ["./fastlane/Appfile", "./.fastlane/Appfile", "./Appfile"].each do |current|
        return current if File.exist?(current)
      end
      nil
    end
```

https://github.com/fastlane/fastlane/blob/9ae433c617a13c0801a9b45f2cf7f8139fbdb427/fastlane/lib/assets/completions/completion.bash#L14

```rb
  # look for Fastfile either in this directory or fastlane/ then grab the lane names
  if [[ -e "Fastfile" ]]; then
    file="Fastfile"
  elif [[ -e "fastlane/Fastfile" ]]; then
    file="fastlane/Fastfile"
  elif [[ -e ".fastlane/Fastfile" ]]; then
    file=".fastlane/Fastfile"
  else
    return 1
  fi
```