### PR TITLE
fix: 🚑 error with persist-credentials=false in the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Setup Platform 🛠
         uses: oven-sh/setup-bun@123c6c4e2fea3eb7bffaa91a85eb6b3d505bf7af # v2


### PR DESCRIPTION
https://github.com/material-extensions/vscode-material-icon-theme/blob/9b7100ed2c206384809b92d8b1c4705f7ce31506/.github/workflows/release.yml#L29-L34

Not persisting credentials while checking out the repository in the `release.yml` action will make the `git push` step to fail with:

```
fatal: could not read Username for 'https://github.com/': No such device or address
```

See a failing example [here](https://github.com/lucodear/lucodear-icons/actions/runs/9786548996/job/27021620014)

Deleting that option [fixed it](https://github.com/lucodear/lucodear-icons/actions/runs/9787261151) and that's what I'm doing in this PR, but there might be another way.

Pinging @lishaduck here for a review (creator of #2365) because he knows much more about github actions than me. Maybe he knows a better way.

