### PR TITLE
Replace generated image previews instead of creating new ones

### DIFF
--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -54,19 +54,25 @@ jobs:
           echo image_url=$IMAGE_URL >> $GITHUB_ENV
         shell: bash
 
-      - name: Post review in PR ✍️
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      - name: Find comment if exists 🕵️
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: fc
         with:
-          script: |
-            const image_url = "${{ env.image_url }}";
-            console.log('URL: '+image_url);
-            const commentBody = '## Preview \n\nThank you for creating a pull request. This preview shows you how your changes will look on the different themes: \n\n ![Generated Preview](' + image_url + ') \n\n You can find more information how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).';
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: This preview shows you how your changes will look on the different themes
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: commentBody
-            })
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post or update comment in PR ✍️
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Preview
+
+            Thank you for creating a pull request. This preview shows you how your changes will look on the different themes:
+
+            ![Generated Preview](${{ env.image_url }})
+
+            You can find more information how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).
+          edit-mode: replace

--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: main
         run: |
           files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$')
-          files_count=$(echo "$files" | wc -w)
+          filesCount=$(echo "$files" | wc -l)
 
           npx svg-icon-review@1.1.0 --bigIcon ${files}
 
@@ -62,36 +62,43 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
-            const imageURL="${{ env.image_url }}"
-            const image = "![Generated preview](${imageURL})"
+            const imageURL = "${{ env.image_url }}";
+            const image = `<img src="${imageURL}" alt="Generated preview" />`;
 
-            let preview = ""
+            let preview = "";
 
-            if (${{ env.svg_files_count }} > 10) {
-              preview += `\
-              <details>
-                <summary>Generated preview</summary>
-
-                ${image}
-
-              </details>`;
-
+            if (parseInt("${{ env.svg_files_count }}") > 10) {
+              preview = `<details><summary>Generated preview</summary>${image}</details>`;
             } else {
-              preview += image;
+              preview = image;
             }
 
-            let comment = `\
-            ## Preview
+            const comment = `
+              ## Preview
 
-            Thank you for creating a pull request. This preview shows you how your changes will look on the different themes:
+              Thank you for creating a pull request. This preview shows you how your changes will look on the different themes:
 
-            ${preview}
+              ${preview}
 
-            You can find more information how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md)`;
+              You can find more information on how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).
+            `;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            })
+            // write comment to environment variable
+            core.exportVariable('comment', comment);
+
+      - name: Find comment if exists 🕵️
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: This preview shows you how your changes will look on the different themes
+
+      - name: Post or update comment in PR ✍️
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ${{ env.comment }}
+          edit-mode: replace

--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -36,12 +36,14 @@ jobs:
           persist-credentials: false
 
       - name: Review SVG files 🔍
+        working-directory: main
         run: |
-          cd main
           files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$')
-          echo "SVG files changed: ${files}"
+          files_count=$(echo "$files" | wc -w)
+
           npx svg-icon-review@1.1.0 --bigIcon ${files}
-          echo svgFiles=$files >> $GITHUB_ENV
+
+          echo svg_files_count=$filesCount >> $GITHUB_ENV
 
       - name: Install jq ⚙️
         run: sudo apt-get install jq
@@ -53,31 +55,43 @@ jobs:
         run: |
           IMAGE_URL=$(curl --location 'https://freeimage.host/json' --form 'source=@"./main/preview.png"' --form 'type="file"' --form 'action="upload"' --form 'auth_token="${{env.IMAGE_UPLOAD}}"' | jq -r '.image.url')
           echo image_url=$IMAGE_URL >> $GITHUB_ENV
-        shell: bash
 
-      - name: Find comment if exists 🕵️
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        id: fc
+      - name: Generate text 📃
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: This preview shows you how your changes will look on the different themes
+          script: |
+            const imageURL="${{ env.image_url }}"
+            const image = "![Generated preview](${imageURL})"
 
-      - name: Post or update comment in PR ✍️
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
+            let preview = ""
+
+            if (${{ env.svg_files_count }} > 10) {
+              preview += `\
+              <details>
+                <summary>Generated preview</summary>
+
+                ${image}
+
+              </details>`;
+
+            } else {
+              preview += image;
+            }
+
+            let comment = `\
             ## Preview
 
             Thank you for creating a pull request. This preview shows you how your changes will look on the different themes:
 
-            <details${{ env.svgFiles < 10 && ' open' || '' }}>
-              <summary>Generated Preview</summary>
+            ${preview}
 
-              ![Generated Preview](${{ env.image_url }})
-            </details>
+            You can find more information how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md)`;
 
-            You can find more information how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).
-          edit-mode: replace
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            })

--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -38,9 +38,10 @@ jobs:
       - name: Review SVG files 🔍
         run: |
           cd main
-          svgFiles=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$')
-          echo "SVG files changed: ${svgFiles}"
-          npx svg-icon-review@1.1.0 --bigIcon ${svgFiles}
+          files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$')
+          echo "SVG files changed: ${files}"
+          npx svg-icon-review@1.1.0 --bigIcon ${files}
+          echo svgFiles=$files >> $GITHUB_ENV
 
       - name: Install jq ⚙️
         run: sudo apt-get install jq
@@ -72,7 +73,11 @@ jobs:
 
             Thank you for creating a pull request. This preview shows you how your changes will look on the different themes:
 
-            ![Generated Preview](${{ env.image_url }})
+            <details${{ env.svgFiles < 10 && ' open' || '' }}>
+              <summary>Generated Preview</summary>
+
+              ![Generated Preview](${{ env.image_url }})
+            </details>
 
             You can find more information how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).
           edit-mode: replace


### PR DESCRIPTION
I noticed that the image preview comments got really long in #2383, so I fixed it.
If you'd like to prevent another #2385, I guess I could make a random edit, check it works, then revert it.