### PR TITLE
ci: 🔄 add link to check pixel perfectness in preview comment

### DIFF
--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -75,6 +75,8 @@ jobs:
 
               ${preview}
 
+              Check how your icon fits in a 16x16 grid with our Pixel Perfect Checker by following [this link](https://pixp.lucode.ar/material-extensions/vscode-material-icon-theme/pull/${{ github.event.pull_request.number }}).
+
               You can find more information on how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).
             `;
 


### PR DESCRIPTION
> [!NOTE]
> ### tl;dr
> 
> adds a link in the "preview comment" to a tool that lets you see how the icon fits in
> a 16x16 grid


Hi!

A while ago, my team and I developed a simple internal tool to check if the icons added by a PR fit ok in a 16x16 pixel grid. A few days ago, we decided to make it open source, adapt it to work with any github repo and hosted it on the web.

Basically, what the web app does is query the GitHub API to get the SVG files added or modified by a PR and display them with an overlaid grid to quickly see if there are any issues. Nothing too fancy, but it ended up being quite useful for us.

This PR simply adds a link referencing the webapp rout to the current PR.

Here's an example:
https://pixp.lucode.ar/material-extensions/vscode-material-icon-theme/pull/2382

![image](https://github.com/user-attachments/assets/918b58fc-c87d-4828-aa8e-20984ddef7fe)

The source code for the application can be found at [lucodear/pixp](https://github.com/lucodear/pixp)

I'm opening this PR as a draft to see if you find it interesting and because the web is hosted on our domain. But you can host it in your own domain if you want! We are using cloudflare.

Cheers!