### PR TITLE
Added icon for `xlf` files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1535,7 +1535,7 @@ export const fileIcons: FileIcons = {
       fileNames: ['makefile', 'gnumakefile', 'kbuild'],
     },
     { name: 'foxpro', fileExtensions: ['fxp', 'prg'] },
-    { name: 'i18n', fileExtensions: ['pot', 'po', 'mo', 'lang'] },
+    { name: 'i18n', fileExtensions: ['pot', 'po', 'mo', 'lang', 'xlf'] },
     { name: 'webassembly', fileExtensions: ['wat', 'wasm'] },
     {
       name: 'semantic-release',


### PR DESCRIPTION
# Description

Files with the extension `.xlf` are localization files, so I think it would be appropriate to use the `i18n` icon for them

**Wiki**: https://en.wikipedia.org/wiki/XLIFF

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
