### PR TITLE
Added separate Buy Me a Coffee link in `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 github: [pkief]
-custom: ['https://paypal.me/philippkief', 'https://buymeacoffee.com/pkief']
+buy_me_a_coffee: pkief
+custom: ['https://paypal.me/philippkief']


### PR DESCRIPTION
# Description

**GitHub** provides the option to add a custom link for [**Buy Me A Coffee**](https://buymeacoffee.com/), then the logo will appear on the left

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
