### PR TITLE
Add lib64 folder icon

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -192,6 +192,7 @@ export const folderIcons: FolderTheme[] = [
           'vendor',
           'vendors',
           'third-party',
+          'lib64',
         ],
       },
       {


### PR DESCRIPTION
Related to #2472

Add an entry for the `lib64` folder in the `folderIcons` array to use the same icon as the `lib` folder.

* Add `lib64` to the `folderNames` array for the `folder-lib` icon in `src/core/icons/folderIcons.ts`.

[Generated with GitHub Copilot Workspace]

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/material-extensions/vscode-material-icon-theme/issues/2472?shareId=7db9e6fa-095f-41cc-8e04-01bc4854fd07).