### PR TITLE
Optimized `.vscodeignore`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,30 +1,20 @@
-.vscode/**
-.github/**
-.vscode-test/**
-out/**
-test/**
-src/**
-scripts/**
-**/*.map
-.gitignore
-tsconfig.json
-tsconfig.**.json
-biome.jsonc
-images/**
-vsc-extension-quickstart.md
-logo.svg
-node_modules
-package-lock.json
-bun.lockb
-yarn.lock
-bunfig.toml
-.devcontainer/**
-sheriff.config.ts
-build/**
-svgo.config.js
-.eslintignore
-material-colors.yml
-changelog.config.json
-dist/types/**
-dist/module.cjs
+# Files to include in the extension package
+# Documentation for this format:
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension#using-.vscodeignore
+!.npmignore
+!CHANGELOG.md
+!LICENSE.md
+!README.md
+!logo.png
 
+!package.json
+!package.nls.*.json
+
+!dist/extension
+!dist/module
+!dist/material-icons.json
+
+!icons
+
+# Exclude everything else
+**/*

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,6 @@
 # Files to include in the extension package
 # Documentation for this format:
 # https://code.visualstudio.com/api/working-with-extensions/publishing-extension#using-.vscodeignore
-!.npmignore
 !CHANGELOG.md
 !LICENSE.md
 !README.md
@@ -11,7 +10,6 @@
 !package.nls.*.json
 
 !dist/extension
-!dist/module
 !dist/material-icons.json
 
 !icons


### PR DESCRIPTION
# Description

I used a "_leave what is necessary_" strategy, instead of adding a **large** list of files that do not need to be added to the **extension package** (which increases the **high** probability of unwanted files getting into the package), I wrote down the files that just need to be left, this is a safer practice and in addition, `.vscodeignore` is now clearer

Here is the file tree in the finished package:

```text
INFO  Files included in the VSIX:
material-icon-theme-5.7.0.vsix
├─ [Content_Types].xml 
├─ extension.vsixmanifest 
└─ extension/
   ├─ .npmignore [0.08 KB]
   ├─ CHANGELOG.md [172.13 KB]
   ├─ LICENSE.md [1.05 KB]
   ├─ README.md [12.38 KB]
   ├─ logo.png [17.32 KB]
   ├─ package.json [10.77 KB]
   ├─ package.nls.cs.json [2.28 KB]
   ├─ package.nls.de.json [2.32 KB]
   ├─ package.nls.es.json [3.28 KB]
   ├─ package.nls.fr.json [2.17 KB]
   ├─ package.nls.ja.json [2.77 KB]
   ├─ package.nls.ko.json [2.33 KB]
   ├─ package.nls.nl.json [2.14 KB]
   ├─ package.nls.pl.json [2.11 KB]
   ├─ package.nls.pt-BR.json [2.11 KB]
   ├─ package.nls.pt-PT.json [2.17 KB]
   ├─ package.nls.ru.json [2.65 KB]
   ├─ package.nls.zh-CN.json [1.9 KB]
   ├─ package.nls.zh-TW.json [1.9 KB]
   ├─ dist/ (4 files) [773.03 KB]
   └─ icons/ (943 files) [844.37 KB]
```

---

And another question, is the `.npmignore` file really necessary?

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
