### PR TITLE
Added `slint` icon

### DIFF
--- a/icons/slint.svg
+++ b/icons/slint.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path fill="#2979ff" d="M 12,1 3,7 8,9 6,7 Z"/>
+    <path fill="#2979ff" d="M 4,15 13,9 8,7 10,9 Z"/>
+</svg>

--- a/icons/slint.svg
+++ b/icons/slint.svg
@@ -1,4 +1,1 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-    <path fill="#2979ff" d="M 12,1 3,7 8,9 6,7 Z"/>
-    <path fill="#2979ff" d="M 4,15 13,9 8,7 10,9 Z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#2979ff" d="M12 1 3 7l5 2-2-2Z"/><path fill="#2979ff" d="m4 15 9-6-5-2 2 2Z"/></svg>

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2535,5 +2535,9 @@ export const fileIcons: FileIcons = {
       name: 'hurl',
       fileExtensions: ['hurl'],
     },
+    {
+      name: 'slint',
+      fileExtensions:['slint', '60']
+    }
   ]),
 };

--- a/src/core/icons/languageIcons.ts
+++ b/src/core/icons/languageIcons.ts
@@ -157,4 +157,5 @@ export const languageIcons: LanguageIcon[] = [
     icon: { name: 'concourse' },
     ids: ['concourse-pipeline-yaml', 'concourse-task-yaml'],
   },
+  { icon: { name: 'slint' }, ids: ['slint'] },
 ];


### PR DESCRIPTION
# Description

Added `slint` icon for file extension (`slint` and `60`) and language id (`slint`)

Source: https://slint.dev/logo/slint-logo-small-light.svg

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
