### PR TITLE
fix(ci): 🚑 first preview comment not being updated

### DIFF
--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: This preview shows you how your changes will look on the different themes
+          body-includes: Thank you for creating a pull request. This preview shows you how your icon
 
       - name: Post or update comment in PR ✍️
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0


### PR DESCRIPTION
# Description

Fixes a regression introduced in #2467 that makes the **review** github action not to update the first comment anymore and create a new one instead.

[See here](https://github.com/material-extensions/vscode-material-icon-theme/pull/2480#issuecomment-2251133809)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
