### PR TITLE
Add inc64 folder icon

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -223,7 +223,14 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-include',
-        folderNames: ['inc', 'include', 'includes', 'partial', 'partials', 'inc64'],
+        folderNames: [
+          'inc',
+          'include',
+          'includes',
+          'partial',
+          'partials',
+          'inc64',
+        ],
       },
       {
         name: 'folder-docker',

--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -223,7 +223,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-include',
-        folderNames: ['inc', 'include', 'includes', 'partial', 'partials'],
+        folderNames: ['inc', 'include', 'includes', 'partial', 'partials', 'inc64'],
       },
       {
         name: 'folder-docker',


### PR DESCRIPTION
Related to #2483

Add `inc64` folder icon to match `inc` folder icon.

* **src/core/icons/folderIcons.ts**
  - Add `inc64` to the `folder-include` entry in the `folderNames` array.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/material-extensions/vscode-material-icon-theme/issues/2483?shareId=2900e6ec-2621-427e-be90-8f2f6bd9ff68).