### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "displayName": "Material Icon Theme",
   "description": "Material Design Icons for Visual Studio Code",
   "version": "5.8.0",
+  "license": "MIT",
   "scripts": {
     "precompile": "rimraf dist && bun run verify",
     "compile": "tsc -p ./",


### PR DESCRIPTION
Closes #2494

Add the `license` field to `package.json` with the value "MIT".