### PR TITLE
fix: 🚑 `.github/labeler.yml` not available

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,6 +13,10 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+    - name: Checkout 🛎️
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Add label for PR 🏷️
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Description

Fixed the error `The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api` that occurred when running `label.yml` (See https://github.com/material-extensions/vscode-material-icon-theme/actions/runs/10141258562/job/28038132986?pr=2496)

Link to fix: https://github.com/actions/labeler/issues/628#issuecomment-1647600431

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
