### PR TITLE
Improve icon review workflow

### DIFF
--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Review SVG files 🔍
         working-directory: main
         run: |
-          files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$' | grep -v '^../main/')
+          files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '^\.\./fork/icons/.*\.svg$')
           filesCount=$(echo "$files" | wc -l)
           bunx --bun svg-icon-review@2.1.0 --bigIcon ${files}
           echo svg_files_count=$filesCount >> $GITHUB_ENV

--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Review SVG files 🔍
         working-directory: main
         run: |
-          files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$')
+          files=$(git diff --no-index ../main ../fork --diff-filter=ACMRTUX --name-only | grep '.svg$' | grep -v '^../main/')
           filesCount=$(echo "$files" | wc -l)
           bunx --bun svg-icon-review@2.1.0 --bigIcon ${files}
           echo svg_files_count=$filesCount >> $GITHUB_ENV


### PR DESCRIPTION
# Description

The command `grep -v '^../main/'` should filter out all files coming from the main repo so that only the file changes from the fork should be shown in the icon review.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../../CODE_OF_CONDUCT.md) and promise to abide by these rules
