### PR TITLE
Include 'devtools' in the folder-icon for 'tools'

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -495,6 +495,7 @@ export const folderIcons: FolderTheme[] = [
           'toolbox',
           'toolboxes',
           'tooling',
+          'devtools',
         ],
       },
       { name: 'folder-helper', folderNames: ['helpers', 'helper'] },


### PR DESCRIPTION
Closes #2527

Add 'devtools' to the folder names associated with the 'tools' icon.

* Modify `src/core/icons/folderIcons.ts` to include 'devtools' in the `folderNames` array for the 'tools' icon.
