### PR TITLE
feat: ✨ .markdownlintignore file icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2553,6 +2553,7 @@ export const fileIcons: FileIcons = {
         '.markdownlint-cli2.yaml',
         '.markdownlint-cli2.cjs',
         '.markdownlint-cli2.mjs',
+        '.markdownlintignore',
       ],
     },
     {


### PR DESCRIPTION
# Description

Hi😊, I added `.markdownlintignore` file into fileNames list which is used by [markdownlint](https://github.com/DavidAnson/markdownlint).

`.markdownlintignore` uses the same icon such as markdownlint(![image](https://github.com/user-attachments/assets/1b7d7d61-ed93-4c1d-ad0f-8da8eac55a4f)). So there is no need to add a new file icon.

This file is mentioned in official README of [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli?tab=readme-ov-file#ignoring-files). (I added a screenshot below.)

![image](https://github.com/user-attachments/assets/025c9d51-ddcf-4dd1-8f35-389138b09d2b)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../CODE_OF_CONDUCT.md) and promise to abide by these rules
