### PR TITLE
docs: 📝 fix broken links in pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@
 
 ## Contribution Guidelines
 
-- [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../CONTRIBUTING.md) for this project.
-- [ ] I have read the [Code Of Conduct](../CODE_OF_CONDUCT.md) and promise to abide by these rules
+- [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
+- [ ] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules


### PR DESCRIPTION
# Description

Hi, I fixed broken links in `pull_request_template.md`.

Relative paths to contribution guide lines and code of conduct make 404 NOT FOUND ERROR.

![image](https://github.com/user-attachments/assets/891eea76-c0e9-4b42-875d-0f77ac9a5f7d)

So I fixed it using URI not relative paths.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](../CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](../CODE_OF_CONDUCT.md) and promise to abide by these rules
