### PR TITLE
feat: ✨ .clang-format-ignore file icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -266,6 +266,7 @@ export const fileIcons: FileIcons = {
         '.yardopts',
         'manifest.mf',
         '.clang-format',
+        '.clang-format-ignore',
         '.clang-tidy',
         '.conf',
       ],


### PR DESCRIPTION
# Description

Hi, I added `.clang-format-ignore` file into fileNames list which is used by [clang-format](https://clang.llvm.org/docs/ClangFormat.html).

It uses the same icon such as `.clang-format`. So there is no need to add a new file icon.

This file is mentioned in [here](https://clang.llvm.org/docs/ClangFormat.html#clang-format-ignore). (I added a screenshot below.)

![image](https://github.com/user-attachments/assets/895f0bf8-71b7-4182-9ced-c1048ae95ef0)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
