### PR TITLE
Fix icon request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-icon-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-icon-request.yml
@@ -11,7 +11,8 @@ body:
       options:
         - label: Folder
         - label: File
-          required: true
+    validations:
+      required: true
 
   - type: textarea
     id: folder-names


### PR DESCRIPTION
Fixes #2588

Update the icon request issue template to allow creating an issue by selecting only the 'Folder' option without requiring the 'File' checkbox.

* Remove the `required: true` attribute for the `File` checkbox in the `.github/ISSUE_TEMPLATE/1-icon-request.yml` file.
* Add a `validations` section with `required: true` for the `icon-type` checkboxes to ensure at least one option is selected.

Based on documentation:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#example-of-bodyi-options-must-not-include-the-reserved-word-none-error
