### PR TITLE
Add .svelte.js and .svelte.ts color variants

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1737,7 +1737,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['svelte.js'],
       clone: {
         base: 'svelte',
-        color: 'yellow-700',
+        color: 'amber-400',
       },
     },
     {
@@ -1745,7 +1745,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['svelte.ts'],
       clone: {
         base: 'svelte',
-        color: 'blue-700',
+        color: 'light-blue-700',
       },
     },
     {
@@ -2066,7 +2066,16 @@ export const fileIcons: FileIcons = {
     { name: 'grain', fileExtensions: ['gr'] },
     { name: 'lolcode', fileExtensions: ['lol'] },
     { name: 'idris', fileExtensions: ['idr', 'ibc'] },
-    { name: 'quasar', fileNames: ['quasar.conf.js', 'quasar.config.js', 'quasar.conf.ts', 'quasar.config.ts', 'quasar.config.cjs'] },
+    {
+      name: 'quasar',
+      fileNames: [
+        'quasar.conf.js',
+        'quasar.config.js',
+        'quasar.conf.ts',
+        'quasar.config.ts',
+        'quasar.config.cjs',
+      ],
+    },
     { name: 'dependabot', fileNames: ['dependabot.yml', 'dependabot.yaml'] },
     { name: 'pipeline', fileExtensions: ['pipeline'] },
     {

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1733,6 +1733,22 @@ export const fileIcons: FileIcons = {
       },
     },
     {
+      name: 'svelte.js',
+      fileExtensions: ['svelte.js'],
+      clone: {
+        base: 'svelte',
+        color: 'yellow-700',
+      },
+    },
+    {
+      name: 'svelte.ts',
+      fileExtensions: ['svelte.ts'],
+      clone: {
+        base: 'svelte',
+        color: 'blue-700',
+      },
+    },
+    {
       name: 'vim',
       fileExtensions: ['vimrc', 'gvimrc', 'exrc', 'vim', 'viminfo'],
     },


### PR DESCRIPTION
# Description

Adds color variants to the Svelte icon for `.svelte.js` and `.svelte.ts` files
Closes https://github.com/material-extensions/vscode-material-icon-theme/issues/2599

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
