### PR TITLE
Fix light mode for language ids

### DIFF
--- a/src/core/generator/languageGenerator.ts
+++ b/src/core/generator/languageGenerator.ts
@@ -61,27 +61,19 @@ const setIconDefinitions = (
   config: Config,
   icon: DefaultIcon
 ) => {
-  manifest = createIconDefinitions(manifest, config, icon.name);
-  manifest = merge(
-    manifest,
-    icon.light
-      ? createIconDefinitions(
-          manifest,
-          config,
-          icon.name + lightColorFileEnding
-        )
-      : manifest.light
-  );
-  manifest = merge(
-    manifest,
-    icon.highContrast
-      ? createIconDefinitions(
-          manifest,
-          config,
-          icon.name + highContrastColorFileEnding
-        )
-      : manifest.highContrast
-  );
+  createIconDefinitions(manifest, config, icon.name);
+
+  if (icon.light) {
+    createIconDefinitions(manifest, config, icon.name + lightColorFileEnding);
+  }
+  if (icon.highContrast) {
+    createIconDefinitions(
+      manifest,
+      config,
+      icon.name + highContrastColorFileEnding
+    );
+  }
+
   return manifest;
 };
 
@@ -96,7 +88,6 @@ const createIconDefinitions = (
       iconPath: `${iconFolderPath}${iconName}${fileConfigHash}.svg`,
     };
   }
-  return manifest;
 };
 
 const setLanguageIdentifiers = (iconName: string, languageIds: string[]) => {


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
Ensure that language icon definitions support different icons for light and dark background themes.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
