### PR TITLE
Add icon association for gltf and glb files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1711,6 +1711,8 @@ export const fileIcons: FileIcons = {
         'vac',
         'vdp',
         'vox',
+        'gltf',
+        'glb',
       ],
     },
     { name: 'buildkite', fileNames: ['buildkite.yml', 'buildkite.yaml'] },


### PR DESCRIPTION
# Description

Added `gltf` and `glb` to the 3d file extensions list

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
