### PR TITLE
ci: update pixp url in icon-review.yml

### DIFF
--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -83,7 +83,7 @@ jobs:
 
               ${preview}
 
-              Check how your icon${pluralS} fit${!pluralS ? 's' : ''} in a 16x16 grid with our **Pixel Perfect Checker** by following [this link](https://pixp.lucode.ar/material-extensions/vscode-material-icon-theme/pull/${{ github.event.pull_request.number }}).
+              Check how your icon${pluralS} fit${!pluralS ? 's' : ''} in a 16x16 grid with our **Pixel Perfect Checker** by following [this link](https://pixp.pages.dev/material-extensions/vscode-material-icon-theme/pull/${{ github.event.pull_request.number }}).
 
               You can find more information on how to contribute in the [contribution guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md).
             `;


### PR DESCRIPTION
# Description

The `pixp.lucode.ar` domain will stop working in about 3 months (I'm progressively moving my domains to `.tech`, `.dev` and `.com`), so this PR changes the url of the pixp link comment (preview in pull requests) to `pixp.pages.dev/...`, which will be alive forever, since it's the default cloudflare domain.

Example of generated url after this change:

https://pixp.pages.dev/material-extensions/vscode-material-icon-theme/pull/2270


## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
