### PR TITLE
add `node` and `nodejs` to folderIcons.ts

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -71,7 +71,7 @@ export const folderIcons: FolderTheme[] = [
         name: 'folder-scripts',
         folderNames: ['script', 'scripts', 'scripting'],
       },
-      { name: 'folder-node', folderNames: ['node_modules'] },
+      { name: 'folder-node', folderNames: ['node', 'nodejs', 'node_modules'] },
       {
         name: 'folder-javascript',
         folderNames: ['js', 'javascript', 'javascripts'],


### PR DESCRIPTION
# Description

i am writing a library that has both web only and node only code in the same package. upon making a `node/` directory i got suprised a little. this plugin doesn't actually show `node/` and `nodejs/` directories, it shows almost everything but _somehow_ missed `node`.

## Contribution Guidelines

- [X] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [ ] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
