### PR TITLE
feat: ✨ `.editorconfig-checker.json` and `.ecrc` file icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1312,7 +1312,14 @@ export const fileIcons: FileIcons = {
     },
     { name: 'fusebox', fileNames: ['fuse.js'] },
     { name: 'heroku', fileNames: ['procfile', 'procfile.windows'] },
-    { name: 'editorconfig', fileNames: ['.editorconfig'] },
+    {
+      name: 'editorconfig',
+      fileNames: [
+        '.editorconfig',
+        '.editorconfig-checker.json',
+        '.ecrc',
+      ],
+    },
     { name: 'gitlab', fileExtensions: ['gitlab-ci.yml'] },
     { name: 'bower', fileNames: ['.bowerrc', 'bower.json'] },
     {


### PR DESCRIPTION
# Description

Hello, I've added `.editorconfig-checker.json` and `.ecrc` file into fileNames list which is used by [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file).

`.editorconfig-checker.json` and `.ecrc` uses the same icon such as `.editorconfig`. So there is no need to add a new file icon.

This file is mentioned in official README of [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#configuration). (I added a screenshot below.)

![image](https://github.com/user-attachments/assets/eddbd61b-83c2-46ff-bb27-f1602f2c6ca8)

## Contribution Guidelines

- [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [ ] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
