### PR TITLE
ci: Add workflow to check PR title following conventional commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,4 @@
 ## Contribution Guidelines
 
 - [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
-- [ ] The PR title follows the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,6 @@
 
 ## Contribution Guidelines
 
-- [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
+- [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
+- [ ] The PR title follows the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # only fetch the config file from the repository
+          # Only fetch the config file from the repository
           sparse-checkout: commitlint.config.js
 
       - name: 📦 Install dependencies

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: ✅ Check PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🔧 Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2
+        with:
+          bun-version-file: ".bun-version"
+
+      - name: 📥 Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # only fetch the config file from the repository
+          sparse-checkout: commitlint.config.js
+
+      - name: 🔍 Check PR title with commitlint
+        run: |
+          bun i @commitlint/config-conventional
+          echo "${{ github.event.pull_request.title }}" | bunx commitlint

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -24,11 +24,4 @@ jobs:
         run: bun i @commitlint/config-conventional
 
       - name: 🔍 Check PR title with commitlint
-        run: echo "${{ github.event.pull_request.title }}" | bunx commitlint
-
-      - name: 🛑 Fail if PR title is incorrect
-        if: failure()
-        run: |
-          echo "Please make sure your PR title follows the Conventional Commit format."
-          echo "Examples: 'feat: add new feature', 'fix: correct bug', 'docs: update documentation'."
-          echo "For more information, see https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md#conventional-pull-request-titles"
+        run: echo "${{ github.event.pull_request.title }}" | bunx commitlint --help-url https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md#conventional-pull-request-titles

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -31,3 +31,4 @@ jobs:
         run: |
           echo "Please make sure your PR title follows the Conventional Commit format."
           echo "Examples: 'feat: add new feature', 'fix: correct bug', 'docs: update documentation'."
+          echo "For more information, see https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md#conventional-pull-request-titles"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,14 @@ jobs:
           # only fetch the config file from the repository
           sparse-checkout: commitlint.config.js
 
+      - name: 📦 Install dependencies
+        run: bun i @commitlint/config-conventional
+
       - name: 🔍 Check PR title with commitlint
+        run: echo "${{ github.event.pull_request.title }}" | bunx commitlint
+
+      - name: 🛑 Fail if PR title is incorrect
+        if: failure()
         run: |
-          bun i @commitlint/config-conventional
-          echo "${{ github.event.pull_request.title }}" | bunx commitlint
+          echo "Please make sure your PR title follows the Conventional Commit format."
+          echo "Examples: 'feat: add new feature', 'fix: correct bug', 'docs: update documentation'."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Glad you're here and interested in expanding this project 🎉 In order to make 
 
 - [Icon Requests](#icon-requests)
 - [Add new icons](#add-new-icons)
+- [Conventional Pull Request Titles](#conventional-pull-request-titles)
 - [How-To's](#how-tos)
   - [Create icon as SVG](#create-icon-as-svg)
   - [Use Material Design colors](#material-design-colors)
@@ -44,6 +45,18 @@ flowchart LR
     C[<a href="#cloning-workflow">Cloning Workflow</a>]
     E[<a href="#creating-new-icons-workflow">Creating New Icons Workflow</a>]
 ```
+
+## Conventional Pull Request Titles
+
+The title of your pull request should follow the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/). When a pull request is merged to the main branch, all changes are going to be squashed into a single commit. The message of this commit will be the title of the pull request. And for every release, the commit messages are used to generate the changelog.
+
+Here are some examples of conventional PR titles:
+
+- `feat: add new icons for Rust`
+- `fix: correct icon for .gitignore`
+- `ci: add GitHub Actions for automated testing`
+
+Generating the changelog based on the commit messages saves time and helps to keep the changelog up-to-date. It also helps to understand the changes in the project.
 
 ### Creating New Icons Workflow
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('@commitlint/types').UserConfig}
+ */
+const config = {
+  extends: ['@commitlint/config-conventional'],
+};
+
+module.exports = config;

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,6 +3,13 @@
  */
 const config = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-case': [
+      2,
+      'never',
+      ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+    ],
+  },
 };
 
 module.exports = config;

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,9 +4,10 @@
 const config = {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    'header-max-length': () => [0, 'always', 72],
     'subject-case': [
-      2,
-      'never',
+      0,
+      'always',
       ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
     ],
   },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,7 +4,6 @@
 const config = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'header-max-length': () => [0, 'always', 72],
     'subject-case': [
       0,
       'always',


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
As we're planning to change the way how we're generating the changelog in the future, we want to have semantic PR titles. While merging a PR we're squashing the commit history of the PR to a single commit on the target (main) branch. The squashed commit will be named after the PR title. That's why this workflow is ensuring that a PR title follows the conventional commit style.

Once we get an invalid PR title the pipeline fails:

![image](https://github.com/user-attachments/assets/8343cb58-d9a3-44f0-a0b7-d32516e1c00a)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
