### PR TITLE
perf(workflows): ⚡optimize checkout steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: 🔧 Setup Bun

--- a/.github/workflows/color-check.yml
+++ b/.github/workflows/color-check.yml
@@ -19,7 +19,6 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: 🎨 Check colors

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: 🔧 Setup Bun

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # Required for fetching tags and generating release notes
+          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: 🔧 Setup Bun


### PR DESCRIPTION
# Description

Checkouts now load only the current commits instead of loading the entire commit history

See https://github.com/actions/checkout#:~:text=Only%20a%20single%20commit%20is%20fetched%20by%20default%2C%20for%20the%20ref/SHA%20that%20triggered%20the%20workflow.%20Set%20fetch%2Ddepth%3A%200%20to%20fetch%20all%20history%20for%20all%20branches%20and%20tags

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
