### PR TITLE
Add more relevant folder name associations

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -421,6 +421,7 @@ export const folderIcons: FolderTheme[] = [
           'measure',
           'measures',
           'measurement',
+          'calculations',
         ],
       },
       {


### PR DESCRIPTION
Add more relevant folder name associations for folder icons.

* Add 'calculations' to the list of folder names associated with the 'folder-measurements' icon in the `specific` theme in `src/core/icons/folderIcons.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/material-extensions/vscode-material-icon-theme?shareId=919e60bb-217a-440e-ac42-3c350ad094cd).