### PR TITLE
fix(workflows): fetch target branch in color check workflow

### DIFF
--- a/.github/workflows/color-check.yml
+++ b/.github/workflows/color-check.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: 🔄 Fetch target branch
+        run: |
+          git fetch origin ${{ env.TARGET_BRANCH }}
+
       - name: 🎨 Check colors
         run: |
           svgFiles=$(git diff origin/${{ env.TARGET_BRANCH }} --diff-filter=ACMRTUX  --name-only | grep '.svg$')


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

Fixes error due to removing of `fetch-depth: 0` in #2681.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
