### PR TITLE
fix: Garden file extensions

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2600,7 +2600,7 @@ export const fileIcons: FileIcons = {
         'project.garden.yaml',
         '.gardenignore',
       ],
-      fileExtensions: ['.garden.yml', '.garden.yaml'],
+      fileExtensions: ['garden.yml', 'garden.yaml'],
     },
     {
       name: 'pkl',


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

Fixes #2692.

Apologies for not double-checking this behavior in my original PR, I hadn't been using files matching that glob pattern and neglected to check.

As you can see this change will fix the bug:

<img width="574" alt="image" src="https://github.com/user-attachments/assets/8c590a86-d48c-4164-8ae9-690d8cfb416b">

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
