### PR TITLE
feat: show Haskell icon for `.lhs` files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -780,7 +780,7 @@ export const fileIcons: FileIcons = {
     { name: 'rust', fileExtensions: ['rs', 'ron'] },
     { name: 'raml', fileExtensions: ['raml'] },
     { name: 'xaml', fileExtensions: ['xaml'] },
-    { name: 'haskell', fileExtensions: ['hs'] },
+    { name: 'haskell', fileExtensions: ['hs', 'lhs'] },
     { name: 'kotlin', fileExtensions: ['kt', 'kts'] },
     {
       name: 'mist',


### PR DESCRIPTION
See https://wiki.haskell.org/Literate_programming#Haskell_and_literate_programming

> In haskell, a literate program is one with the suffix `.lhs` rather than `.hs`.

# Description

- Add `'lhs'` to Haskell's `fileExtensions`

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
