### PR TITLE
feat: add .hgtags icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2516,6 +2516,7 @@ export const fileIcons: FileIcons = {
         '.hg',
         '.hgignore',
         '.hgflow',
+        '.hgtags',
         '.hgrc',
         'hgrc',
         'mercurial.ini',


### PR DESCRIPTION
# Description

Supplement to [#198](https://github.com/material-extensions/vscode-material-icon-theme/pull/1898).

add [`.hgtags`](https://wiki.mercurial-scm.org/Tag#What_if_multiple_lines_with_different_revisions_use_the_same_tag_name_in_.hgtags.3F) icon.
