### PR TITLE
feat: add `.dev.vars` association to `env` file icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1262,6 +1262,7 @@ export const fileIcons: FileIcons = {
         '.env.test.local',
         '.env.uat',
         '.vars',
+        '.dev.vars',
       ],
     },
     {


### PR DESCRIPTION
# Description

Adds `.dev.vars` to the association list of the env file icon.

### Purpose
 
`.dev.vars` is used to set environment variables for local development of cloudflare workers (see [here](https://developers.cloudflare.com/workers/configuration/environment-variables/#:~:text=For%20local%20development%20with%20wrangler%20dev%2C%20variables%20in%20wrangler.toml%20are%20automatically%20overridden%20by%20any%20values%20defined%20in%20a%20.dev.vars%20file%20located%20in%20the%20root%20directory%20of%20your%20worker.%20This%20is%20useful%20for%20providing%20values%20you%20do%20not%20want%20to%20check%20in%20to%20source%20control.))

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
