### PR TITLE
feat: ✨ add icon for `.tool-versions` file

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -301,6 +301,7 @@ export const fileIcons: FileIcons = {
         'sln.dotsettings.user',
         'cfg',
         'cnf',
+        '.tool-versions',
       ],
       fileNames: [
         '.jshintignore',


### PR DESCRIPTION
# Description

Adds `.tool-versions` association. Used in [asdf](https://github.com/asdf-vm/asdf) as a config file to manage multiple runtime versions.

https://asdf-vm.com/manage/configuration.html#tool-versions

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
