### PR TITLE
feat: add bun.lock to bun fileNames

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2475,7 +2475,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'bun',
-      fileNames: ['bun.lockb', 'bunfig.toml', '.bun-version'],
+      fileNames: ['bun.lockb', 'bunfig.toml', '.bun-version', 'bun.lock'],
       light: true,
     },
     { name: 'antlr', fileExtensions: ['g4'] },


### PR DESCRIPTION
# Description

🎉 We have bun lock as text file now: https://bun.sh/blog/bun-v1.1.39#bun-lock-is-bun-s-new-text-based-lockfile

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
