### PR TITLE
chore(workflows): :construction_worker: Add workflow to close inactive issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,26 @@
+# This workflow closes issues with the label "info-needed" or "invalid" that have been inactive for 14 days since being marked as stale.
+name: ❌ Close inactive issues
+on:
+  schedule:
+    # It is triggered every day at 1:30 AM UTC.
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          any-of-labels: "info-needed,invalid"
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,4 +1,4 @@
-# This workflow closes issues with the label "info-needed" or "invalid" that have been inactive for 14 days since being marked as stale.
+# This workflow closes issues with the labels "info-needed" or "invalid" that have been inactive for 14 days since being marked as stale.
 name: ❌ Close inactive issues
 on:
   schedule:


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
Closes inactive issues after some time. Some issues are marked as ["info-needed"](https://github.com/material-extensions/vscode-material-icon-theme/labels/info-needed) and "invalid". As there's no update or any further comment in this issue, then we should close these issues as they cannot be proceeded. This workflow checks every nigth, if we have issues which are stale and can be closed.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
