### PR TITLE
fix: :bug: fix issue with disabled base icons of clones

### DIFF
--- a/src/core/generator/clones/clonesGenerator.ts
+++ b/src/core/generator/clones/clonesGenerator.ts
@@ -96,7 +96,8 @@ export const generateConfiguredClones = async (
   for (const icon of iconsToClone) {
     const clones = getCloneData(icon, manifest, '', '', cloneIconExtension);
     if (!clones) {
-      return;
+      // no clones to be created and continue with the next icon
+      continue;
     }
 
     for (const clone of clones) {

--- a/src/core/generator/fileGenerator.ts
+++ b/src/core/generator/fileGenerator.ts
@@ -31,6 +31,7 @@ export const loadFileIconDefinitions = (
   const enabledIcons = disableIconsByPack(fileIcons, config.activeIconPack);
   const customIcons = getCustomIcons(config.files?.associations);
   const allFileIcons = [...fileIcons.icons, ...customIcons];
+  const allEnabledIcons = [...enabledIcons, ...customIcons];
 
   allFileIcons.forEach((icon) => {
     const isClone = icon.clone !== undefined;
@@ -57,7 +58,7 @@ export const loadFileIconDefinitions = (
   });
 
   // Only map the specific file icons if they are enabled depending on the active icon pack
-  enabledIcons.forEach((icon) => {
+  allEnabledIcons.forEach((icon) => {
     if (icon.disabled) return;
     if (icon.fileExtensions) {
       manifest = mapSpecificFileIcons(

--- a/src/core/generator/fileGenerator.ts
+++ b/src/core/generator/fileGenerator.ts
@@ -30,10 +30,9 @@ export const loadFileIconDefinitions = (
 ): Manifest => {
   const enabledIcons = disableIconsByPack(fileIcons, config.activeIconPack);
   const customIcons = getCustomIcons(config.files?.associations);
-  const allFileIcons = [...enabledIcons, ...customIcons];
+  const allFileIcons = [...fileIcons.icons, ...customIcons];
 
   allFileIcons.forEach((icon) => {
-    if (icon.disabled) return;
     const isClone = icon.clone !== undefined;
     manifest = setIconDefinition(manifest, config, icon.name, isClone);
 
@@ -55,7 +54,11 @@ export const loadFileIconDefinitions = (
         highContrastColorFileEnding
       );
     }
+  });
 
+  // Only map the specific file icons if they are enabled depending on the active icon pack
+  enabledIcons.forEach((icon) => {
+    if (icon.disabled) return;
     if (icon.fileExtensions) {
       manifest = mapSpecificFileIcons(
         icon,

--- a/src/core/generator/folderGenerator.ts
+++ b/src/core/generator/folderGenerator.ts
@@ -38,6 +38,7 @@ export const loadFolderIconDefinitions = (
   const enabledIcons = disableIconsByPack(activeTheme, config.activeIconPack);
   const customIcons = getCustomIcons(config.folders?.associations);
   const allIcons = [...(activeTheme.icons ?? []), ...customIcons];
+  const allEnabledIcons = [...enabledIcons, ...customIcons];
 
   if (config.folders?.theme === 'none') {
     return manifest;
@@ -48,7 +49,7 @@ export const loadFolderIconDefinitions = (
   });
 
   // Only map the specific folder icons if they are enabled depending on the active icon pack
-  enabledIcons.forEach((icon) => {
+  allEnabledIcons.forEach((icon) => {
     if (icon.disabled) return;
     const folderNames = extendFolderNames(icon.folderNames);
     manifest = merge(manifest, setFolderNames(icon.name, folderNames));

--- a/src/core/generator/folderGenerator.ts
+++ b/src/core/generator/folderGenerator.ts
@@ -37,16 +37,20 @@ export const loadFolderIconDefinitions = (
   }
   const enabledIcons = disableIconsByPack(activeTheme, config.activeIconPack);
   const customIcons = getCustomIcons(config.folders?.associations);
-  const allIcons = [...enabledIcons, ...customIcons];
+  const allIcons = [...(activeTheme.icons ?? []), ...customIcons];
 
   if (config.folders?.theme === 'none') {
     return manifest;
   }
 
   allIcons.forEach((icon) => {
+    manifest = setIconDefinitions(manifest, config, icon);
+  });
+
+  // Only map the specific folder icons if they are enabled depending on the active icon pack
+  enabledIcons.forEach((icon) => {
     if (icon.disabled) return;
     const folderNames = extendFolderNames(icon.folderNames);
-    manifest = setIconDefinitions(manifest, config, icon);
     manifest = merge(manifest, setFolderNames(icon.name, folderNames));
     manifest.light = icon.light
       ? merge(

--- a/src/core/generator/languageGenerator.ts
+++ b/src/core/generator/languageGenerator.ts
@@ -29,11 +29,15 @@ export const loadLanguageIconDefinitions = (
     config.activeIconPack
   );
   const customIcons = getCustomIcons(config.languages?.associations);
-  const allLanguageIcons = [...enabledLanguages, ...customIcons];
+  const allLanguageIcons = [...languageIcons, ...customIcons];
 
   allLanguageIcons.forEach((lang) => {
-    if (lang.disabled) return;
     manifest = setIconDefinitions(manifest, config, lang.icon);
+  });
+
+  // Only map the specific language icons if they are enabled depending on the active icon pack
+  enabledLanguages.forEach((lang) => {
+    if (lang.disabled) return;
     manifest = merge(
       manifest,
       setLanguageIdentifiers(lang.icon.name, lang.ids)

--- a/src/core/generator/languageGenerator.ts
+++ b/src/core/generator/languageGenerator.ts
@@ -30,13 +30,14 @@ export const loadLanguageIconDefinitions = (
   );
   const customIcons = getCustomIcons(config.languages?.associations);
   const allLanguageIcons = [...languageIcons, ...customIcons];
+  const allEnabledLanguageIcons = [...enabledLanguages, ...customIcons];
 
   allLanguageIcons.forEach((lang) => {
     manifest = setIconDefinitions(manifest, config, lang.icon);
   });
 
   // Only map the specific language icons if they are enabled depending on the active icon pack
-  enabledLanguages.forEach((lang) => {
+  allEnabledLanguageIcons.forEach((lang) => {
     if (lang.disabled) return;
     manifest = merge(
       manifest,

--- a/src/core/tests/icons/fileIcons.test.ts
+++ b/src/core/tests/icons/fileIcons.test.ts
@@ -89,6 +89,9 @@ describe('file icons', () => {
     );
 
     expectedManifest.iconDefinitions = {
+      angular: {
+        iconPath: './../icons/angular.svg',
+      },
       file: {
         iconPath: './../icons/file.svg',
       },

--- a/src/core/tests/icons/folderIcons.test.ts
+++ b/src/core/tests/icons/folderIcons.test.ts
@@ -261,6 +261,12 @@ describe('folder icons', () => {
       folder: {
         iconPath: './../icons/folder.svg',
       },
+      'folder-angular': {
+        iconPath: './../icons/folder-angular.svg',
+      },
+      'folder-angular-open': {
+        iconPath: './../icons/folder-angular-open.svg',
+      },
       'folder-open': {
         iconPath: './../icons/folder-open.svg',
       },

--- a/src/core/tests/icons/languageIcons.test.ts
+++ b/src/core/tests/icons/languageIcons.test.ts
@@ -64,6 +64,9 @@ describe('language icons', () => {
       a: {
         iconPath: './../icons/a.svg',
       },
+      c: {
+        iconPath: './../icons/c.svg',
+      },
     };
     expectedManifest.languageIds = {
       a: 'a',
@@ -85,7 +88,14 @@ describe('language icons', () => {
       manifest
     );
 
-    expectedManifest.iconDefinitions = {};
+    expectedManifest.iconDefinitions = {
+      a: {
+        iconPath: './../icons/a.svg',
+      },
+      c: {
+        iconPath: './../icons/c.svg',
+      },
+    };
     expectedManifest.languageIds = {};
     expect(iconDefinitions).toStrictEqual(expectedManifest);
   });


### PR DESCRIPTION
# Description

If a base icon of a configured clone is initially disabled via icon package, then the creation of the clone icon is not working, even when the icon pack is enabled.

## Current behavior

The following code snippets demonstrate the edge case in which the clone functionality is not properly working. We add a new folder called `folder-bug` which should clone from the base folder `folder-base`:

```ts
{
  name: 'folder-bug',
  folderNames: ['bug'],
  clone: {
    base: 'folder-base',
    color: 'light-blue-700',
  },
},
```

The `folder-base` icon is not enabled all the time, but only if the `IconPack.React` is enabled:

```ts
{
    name: 'folder-base',
    folderNames: ['base'],
    enabledFor: [IconPack.React],
},
```

We keep the icon pack configuration at its default value:

```json
{
  "material-icon-theme.activeIconPack": "angular"
}
```

### Result

The clone is not generated, because the icon definition is not set at this point. There's no entry for `folder-base` in the manifest and therefor it won't be able to generate the clone which is based on an icon definition which is not existing at this point. Even changing the active icon pack to `react` is not fixing this behavior, because the generation of the configured icon clones takes only place at build time and not at runtime.

![image](https://github.com/user-attachments/assets/4a62c9fd-5e54-4f74-bf61-da15207239af)

### Solution

We keep the icon definitions at all time in the manifest, even if an icon is disabled or not available via icon pack. This makes it possible to clone from disabled icons to generate new icons out of it.

![image](https://github.com/user-attachments/assets/db53a113-e24a-4468-a168-7179ef64df3c)

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
