### PR TITLE
chore: 🔒 make `bun.lock` readonly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,18 +1,26 @@
 {
+  "files.readonlyInclude": {
+    "bun.lock": true
+  },
   "files.exclude": {
     "out": false
   },
   "search.exclude": {
     "out": true
   },
+
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+
   "[typescript]": {
     "editor.codeActionsOnSave": {
       "quickfix.biome": "explicit",
       "source.organizeImports.biome": "explicit"
     }
   },
-  "editor.defaultFormatter": "biomejs.biome",
-  "editor.formatOnSave": true,
+  "[markdown]": {
+    "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+  },
 
   "github.copilot.chat.codeGeneration.instructions": [
     {
@@ -27,8 +35,5 @@
       "file": "/CONTRIBUTING.md"
     }
   ],
-  "github.copilot.chat.codeGeneration.useInstructionFiles": true,
-  "[markdown]": {
-    "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
-  }
+  "github.copilot.chat.codeGeneration.useInstructionFiles": true
 }


### PR DESCRIPTION
# Description

* Added `files.readonlyInclude` for `bun.lock` to prevent accidental modifications.
* Improved settings structure for better readability.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
