### PR TITLE
fix(ci): 🚑 use `pull_request_target` instead of `pull_request`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
       - 'sheriff.config.ts'
       - '!*.md'
 
-  pull_request:
+  pull_request_target:
     paths:
       - 'build/**'
       - 'icons/*.svg'

--- a/.github/workflows/color-check.yml
+++ b/.github/workflows/color-check.yml
@@ -1,7 +1,7 @@
 name: 🎨 Check SVG icon colors
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "icons/*.svg"
 

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,7 +1,7 @@
 name: 🎉 PR closed
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: ✅ Check PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited]
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: ✅ Check PR Title
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 permissions:


### PR DESCRIPTION
# Description

This will fix the falling workflows
`pull_request_target` unlike `pull_request` grants write access to `GITHUB_TOKEN`¹ `pull_request_target` is recommended to be used only where tasks such as commenting and labeling² are very necessary, which is what we need

You can read more about my discovery of the problem starting from this comment in #2365: https://github.com/material-extensions/vscode-material-icon-theme/pull/2365#issuecomment-2599772182

2: https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git#:~:text=The%20pull_request_tar get%20event%20grants%20workflows%20triggered%20by%20pull%20requests%20from%20forks%20access%20to%20repository%20secrets%20and%20a%20read/write%20GITHUB_TOKEN
2: https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git#:~:text=only%20use%20pull_request_target %20for%20workflow ws%20where%20access%20to%20secrets%20or%20write%20permissions%20is%20strictly%20necessary%2C%20such%20as%20commenting%2C%20labeling%2C%20or%20status%20updates%20on%20pull%20requests.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
