### PR TITLE
feat: add `websites` folder icon

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -241,6 +241,7 @@ export const folderIcons: FolderTheme[] = [
           'wwwroot',
           'web',
           'website',
+          'websites',
           'site',
           'browser',
           'browsers',


### PR DESCRIPTION
# Description

Hello,  

I’ve added the `websites` folder icon to the `folder-public` list.  

Since the `websites` folder is commonly used in the same way as the `website` folder, I believe it’s better to include `websites` as well.

## Contribution Guidelines

- [X] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [X] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
