### PR TITLE
feat: add icon for temporary files (`.tmp`, `.temp`)

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2376,7 +2376,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['bubble', 'html.bubble', 'php.bubble'],
     },
     { name: 'teal', fileExtensions: ['tl'] },
-    { name: 'template', fileExtensions: ['template'] },
+    { name: 'template', fileExtensions: ['template', 'temp', 'tmp'] },
     { name: 'astyle', fileNames: ['.astylerc'] },
     {
       name: 'shader',


### PR DESCRIPTION
# Description

I think the template file icon is suitable for this type of file

Closes #2196

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
