### PR TITLE
Fix folderIcons.ts

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -90,7 +90,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-directive',
-        folderNames: ['directive, directives'],
+        folderNames: ['directive', 'directives'],
       },
       {
         name: 'folder-jinja',


### PR DESCRIPTION
# Description
Changed  `folderNames: ['directive, directives']` to `folderNames: ['directive', 'directives']`

I was making a list in vscode of the different folders and noticed the mistake that "directive, directives" was one folder name instead of "directive", "directives"

![Screenshot 2025-02-17 102604](https://github.com/user-attachments/assets/8ad6db0f-9646-46c2-a643-e9b22c65c5f6)


## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
