### PR TITLE
Add `.sub` extension to subtitle files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3038,7 +3038,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'subtitles',
-      fileExtensions: ['srt', 'ssa', 'ttml', 'sbv', 'dfxp', 'vtt'],
+      fileExtensions: ['srt', 'ssa', 'ttml', 'sbv', 'dfxp', 'vtt', 'sub'],
     },
     { name: 'beancount', fileExtensions: ['beancount', 'bean'] },
     {

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -301,7 +301,7 @@ export const fileIcons: FileIcons = {
         'sln.dotsettings.user',
         'cfg',
         'cnf',
-        '.tool-versions',
+        'tool-versions',
       ],
       fileNames: [
         '.jshintignore',

--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -90,7 +90,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-directive',
-        folderNames: ['directive, directives'],
+        folderNames: ['directive', 'directives'],
       },
       {
         name: 'folder-jinja',


### PR DESCRIPTION
# Description

Added the `.sub` file extension to the subtitle files

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
