### PR TITLE
feat: add uv icon

### DIFF
--- a/icons/uv.svg
+++ b/icons/uv.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="#E040FB" d="M2 2v11c0 .5.5 1 1 1h8c.5 0 1-.5 1-1h1v1h1V2H8v8H7V2H2z"/></svg>

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -497,6 +497,7 @@ export const fileIcons: FileIcons = {
       name: 'ruff',
       fileNames: ['ruff.toml', '.ruff.toml'],
     },
+    { name: 'uv', fileNames: ['uv.toml', '.uv.toml'] },
     {
       name: 'scons',
       light: true,


### PR DESCRIPTION
# Description

Adds an icon for [uv](https://docs.astral.sh/uv/) config files, based on the uv tool logo.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
