### PR TITLE
feat: ✨ enhance cloning so two-color icons adhere to same-palette rule

### DIFF
--- a/src/core/generator/clones/utils/color/colors.ts
+++ b/src/core/generator/clones/utils/color/colors.ts
@@ -109,6 +109,16 @@ export const replacementMap = (baseColor: string, colors: Set<string>) => {
     const color = chroma(orderedColors[i]);
     let newColor = color.set('hsl.h', baseHue);
 
+    // if it's a simple, 2-color icon, we also retain the saturation
+    // from the base color. This helps us better adhere to the
+    // same-palette rule in the extension's guidelines; keeping both
+    // colors within the same "color column" of the material palette.
+    // This mainly affects folder icons, which usually have 2-color
+    // designs.
+    if (orderedColors.length === 2) {
+      newColor = newColor.set('hsl.s', baseColorChroma.get('hsl.s'));
+    }
+
     // the idea is to keep the paths with the same relative darkness
     // as the original icon, but with different hues. So if the
     // new color results in a darker color (as we are looping from


### PR DESCRIPTION
# Description

I was working on a `migrations` folder icon (rel: #895) by cloning the `folder-database` and this was the result:

![Captura de pantalla 2025-03-09 032848](https://github.com/user-attachments/assets/e141766d-6ba6-4665-8833-dc0395490c3c)

As you can see, the color in the motif path is from the `light-blue` palette, while the chosen base color was in the `blue-gray` palette.

I think this issue occurs due to two factors:

- The original icon being cloned was yellow, and yellow icons tend to have less contrast between dark and light variations
- the `blue-gray` and `light-blue` palettes have similar hue values, but very different saturations and luminances.

Since we are only playing with the hue and luminance values of the colors, the result ends up with a color from the `light-blue` palette instead of `blue-gray`.

This PR ensures the saturation of the base color is maintained when selecting the motif color, so the resulting color comes from the same palette as the base color.

![image](https://github.com/user-attachments/assets/592a7ee5-3334-4ef7-996f-d7619b798f83)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
