### PR TITLE
feat: add the subtitle icon to `.ass` files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3054,7 +3054,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'subtitles',
-      fileExtensions: ['srt', 'ssa', 'ttml', 'sbv', 'dfxp', 'vtt', 'sub'],
+      fileExtensions: ['srt', 'ssa', 'ttml', 'sbv', 'dfxp', 'vtt', 'sub', 'ass'],
     },
     { name: 'beancount', fileExtensions: ['beancount', 'bean'] },
     {

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3062,7 +3062,7 @@ export const fileIcons: FileIcons = {
         'dfxp',
         'vtt',
         'sub',
-        'ass'
+        'ass',
       ],
     },
     { name: 'beancount', fileExtensions: ['beancount', 'bean'] },

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3054,7 +3054,16 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'subtitles',
-      fileExtensions: ['srt', 'ssa', 'ttml', 'sbv', 'dfxp', 'vtt', 'sub', 'ass'],
+      fileExtensions: [
+        'srt',
+        'ssa',
+        'ttml',
+        'sbv',
+        'dfxp',
+        'vtt',
+        'sub',
+        'ass'
+      ],
     },
     { name: 'beancount', fileExtensions: ['beancount', 'bean'] },
     {


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
Added the subtitle icon to Advanced SubStation Alpha (`.ass`) subtitle files.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
