### PR TITLE
feat: add support for more Python-adjacent file types

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -488,7 +488,7 @@ export const fileIcons: FileIcons = {
     { name: 'python', fileExtensions: ['py'] },
     {
       name: 'python-misc',
-      fileExtensions: ['pyc', 'whl'],
+      fileExtensions: ['pyc', 'whl', 'egg'],
       fileNames: [
         'requirements.txt',
         'pipfile',

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -498,6 +498,11 @@ export const fileIcons: FileIcons = {
         '.pylintrc',
         'pyproject.toml',
         'py.typed',
+        '.coveragerc',
+        '.coverage',
+        '.scrapy',
+        'celerybeat-schedule',
+        'celerybeat.pid',
       ],
     },
     {


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
Adding the `python-misc` icon to the following Python-adjacent file types:
1. *.egg
2. .coveragerc
3. .coverage
4. .scrapy
5. celerybeat-schedule
6. celerybeat.pid

All of these previously had no icon associated with them.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
