### PR TITLE
feat(icons): add support for `turbo.jsonc` file in turborepo icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1389,7 +1389,7 @@ export const fileIcons: FileIcons = {
     {
       name: 'turborepo',
       light: true,
-      fileNames: ['turbo.json'],
+      fileNames: ['turbo.json', 'turbo.jsonc'],
     },
     {
       name: 'babel',


### PR DESCRIPTION
# Description

Turborepo now supports JSONC, as documented at <https://turbo.build/docs/reference/configuration>.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
