### PR TITLE
feat: add plural folder names for folder-sandbox icon

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -523,7 +523,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-sandbox',
-        folderNames: ['sandbox', 'playground'],
+        folderNames: ['sandbox', 'sandboxes', 'playground', 'playgrounds'],
       },
       {
         name: 'folder-scons',


### PR DESCRIPTION
# Description

This PR updates the `folder-sandbox` icon definition to include plural forms of existing folder names.
Added `sandboxes` and `playgrounds` folder names.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
