### PR TITLE
feat: associate the `.ets` and `.d.ets` extensions to typescript icon to support the ArkTS language

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -324,7 +324,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'typescript-def',
-      fileExtensions: ['d.ts', 'd.cts', 'd.mts'],
+      fileExtensions: ['d.ts', 'd.cts', 'd.mts', 'd.ets'],
     },
     { name: 'markdoc', fileExtensions: ['mdoc', 'markdoc', 'markdoc.md'] },
     {

--- a/src/core/icons/languageIcons.ts
+++ b/src/core/icons/languageIcons.ts
@@ -28,7 +28,7 @@ export const languageIcons: LanguageIcon[] = [
   { name: 'python', ids: ['python'] },
   { name: 'mojo', ids: ['mojo'] },
   { name: 'javascript', ids: ['javascript'] },
-  { name: 'typescript', ids: ['typescript'] },
+  { name: 'typescript', ids: ['typescript', 'ets'] },
   { name: 'scala', ids: ['scala'] },
   { name: 'handlebars', ids: ['handlebars'] },
   { name: 'perl', ids: ['perl', 'perl6'] },


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

ArkTS is a superset of TypeScript open sourced by the [OpenHarmony organization](https://en.wikipedia.org/wiki/OpenHarmony) to support the development of the HarmonyOS App. I recently created an [ArkTS VSCode plugin](https://github.com/Groupguanfang/arkTS) that supports the code highlighting and completion of the ArkTS language. 

I love using this material icon theme, There are relatively few people using ArkTS on VSCode at the moment, and there seems to be no official file icon for ArkTS available at the moment. So I simply associated TypeScript icon with ArkTS in a simple way (with just a few minor changes). Hope the author approves this PR🥹Thank you very much indeed🙏

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
