### PR TITLE
feat: add bench and perf to benchmark folder icon

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -486,7 +486,9 @@ export const folderIcons: FolderTheme[] = [
         folderNames: [
           'benchmark',
           'benchmarks',
+          'bench',
           'performance',
+          'perf',
           'profiling',
           'measure',
           'measures',


### PR DESCRIPTION
# Description

add `bench` and `perf` folder names to benchmark folder icon

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
