### PR TITLE
feat: add `supabase.ts` to list of supabase icons

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2469,7 +2469,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'supabase',
-      fileNames: ['supabase.js', 'supabase.py'],
+      fileNames: ['supabase.js', 'supabase.ts', 'supabase.py'],
     },
     {
       name: 'ember',


### PR DESCRIPTION
# Description
Add `supabase.ts` to list of files that appear with a Supabase icon. TypeScript support since icon already appears for `supabase.js`.

## Contribution Guidelines

- [X] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [X] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
