### PR TITLE
feat: associate Docker icon to `dockerbake` language ID

### DIFF
--- a/src/core/icons/languageIcons.ts
+++ b/src/core/icons/languageIcons.ts
@@ -94,7 +94,7 @@ export const languageIcons: LanguageIcon[] = [
   { name: 'tex', ids: ['tex', 'doctex', 'latex', 'latex-expl3'] },
   { name: 'salesforce', ids: ['apex'] },
   { name: 'sas', ids: ['sas'] },
-  { name: 'docker', ids: ['dockerfile', 'dockercompose'] },
+  { name: 'docker', ids: ['dockerfile', 'dockercompose', 'dockerbake'] },
   { name: 'table', ids: ['csv', 'tsv', 'psv'] },
   { name: 'csharp', ids: ['csharp'] },
   { name: 'console', ids: ['bat', 'awk', 'shellscript'] },


### PR DESCRIPTION
# Description

This pull request just associates the Docker icon to the `dockerbake` language ID.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules