### PR TITLE
feat: add .xsh to console icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -531,7 +531,7 @@ export const fileIcons: FileIcons = {
         'fish',
         'exp',
         'nu',
-        'xsh'
+        'xsh',
       ],
       fileNames: ['commit-msg', 'pre-commit', 'pre-push', 'post-merge'],
     },

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -531,6 +531,7 @@ export const fileIcons: FileIcons = {
         'fish',
         'exp',
         'nu',
+        'xsh'
       ],
       fileNames: ['commit-msg', 'pre-commit', 'pre-push', 'post-merge'],
     },


### PR DESCRIPTION
# Description

Adds `.xsh` files (used by the Xonsh shell) to the list of extensions mapped to the existing `console` icon. This is consistent with how other shell script extensions like `sh`, `fish`, and `nu` are handled.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
