### PR TITLE
Add datastructure folder icon SVG

### DIFF
--- a/icons/datastructure.svg
+++ b/icons/datastructure.svg
@@ -1,21 +1,24 @@
-<svg width="284" height="151" viewBox="0 0 284 151" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="284" height="151" fill="#1E1E1E"/>
-<ellipse cx="141.5" cy="17" rx="55.5" ry="17" fill="white"/>
-<ellipse cx="141.5" cy="134" rx="55.5" ry="17" fill="white"/>
-<ellipse cx="141.5" cy="56" rx="55.5" ry="17" fill="white"/>
-<ellipse cx="141.5" cy="97" rx="55.5" ry="17" fill="white"/>
-<line x1="197" y1="77" x2="268" y2="77" stroke="white" stroke-width="2"/>
-<line x1="16" y1="77" x2="87" y2="77" stroke="white" stroke-width="2"/>
-<path d="M197 50L243.158 50L263 28" stroke="white" stroke-width="2"/>
-<path d="M86.6158 103.847L40.4577 103.847L20.6158 125.847" stroke="white" stroke-width="2"/>
-<path d="M86.6158 50L40.4577 50L20.6158 28" stroke="white" stroke-width="2"/>
-<path d="M198 106.847L244.158 106.847L264 128.847" stroke="white" stroke-width="2"/>
-<rect x="268" y="71" width="16" height="16" fill="white"/>
-<rect y="71" width="16" height="16" fill="white"/>
-<circle cx="16" cy="23" r="7" fill="white"/>
-<circle cx="269" cy="132" r="7" fill="white"/>
-<circle cx="16" cy="132" r="7" fill="white"/>
-<circle cx="269" cy="24" r="7" fill="white"/>
-<line x1="87.5" y1="18" x2="87.5" y2="133" stroke="white" stroke-width="3"/>
-<path d="M196 18L196 133" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="152" height="100" viewBox="0 0 152 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="152" height="100" fill="#1E1E1E"/>
+<ellipse cx="93" cy="40.5" rx="23" ry="7.5" fill="white"/>
+<ellipse cx="93" cy="91.5" rx="23" ry="7.5" fill="white"/>
+<ellipse cx="93" cy="57.5" rx="23" ry="7.5" fill="white"/>
+<ellipse cx="93" cy="75.5" rx="23" ry="7.5" fill="white"/>
+<line x1="116" y1="66" x2="145" y2="66" stroke="white" stroke-width="2"/>
+<line x1="41" y1="66" x2="70" y2="66" stroke="white" stroke-width="2"/>
+<path d="M115.852 54.8543L135.03 54.8543L143.275 45.2384" stroke="white" stroke-width="2"/>
+<path d="M69.9883 78.3903L50.8099 78.3903L42.5657 88.0062" stroke="white" stroke-width="2"/>
+<path d="M69.9883 54.8543L50.8099 54.8543L42.5657 45.2384" stroke="white" stroke-width="2"/>
+<path d="M116.268 79.7015L135.446 79.7015L143.69 89.3174" stroke="white" stroke-width="2"/>
+<rect x="145" y="63" width="7" height="7" fill="white"/>
+<rect x="34" y="63" width="7" height="7" fill="white"/>
+<circle cx="41" cy="43" r="3" fill="white"/>
+<circle cx="146" cy="91" r="3" fill="white"/>
+<circle cx="41" cy="91" r="3" fill="white"/>
+<ellipse cx="146" cy="43.5" rx="3" ry="3.5" fill="white"/>
+<line x1="71.5" y1="41" x2="71.5" y2="91" stroke="white" stroke-width="3"/>
+<path d="M115 41L115 91" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<g style="mix-blend-mode:lighten">
+<path d="M59.2188 7.68225L52.7813 2.31775C50.9842 0.820149 48.7189 -1.51695e-07 46.3796 0H10C7.34784 0 4.8043 1.05357 2.92893 2.92893C1.05357 4.8043 0 7.34784 0 10V90C0 92.6522 1.05357 95.1957 2.92893 97.0711C4.8043 98.9464 7.34784 100 10 100H130C132.652 100 135.196 98.9464 137.071 97.0711C138.946 95.1957 140 92.6522 140 90V20C140 17.3478 138.946 14.8043 137.071 12.9289C135.196 11.0536 132.652 10 130 10H65.6206C63.2813 10 61.0159 9.17985 59.2188 7.68225Z" fill="#555A5E"/>
+</g>
 </svg>


### PR DESCRIPTION
# Description

Added a new SVG file for the `datastructure` folder icon in the `icons/folder` directory. This icon represents data structures visually (like stack, queue, tree, etc.) and is intended to improve recognition of such folders in VS Code.

This PR only includes the SVG file. The integration into the icon theme (e.g., mapping in `folderIcons.ts`) is left for maintainers or a future PR.

## Contribution Guidelines

- [X] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [X] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.
