### PR TITLE
feat: add new config file for Prisma

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1894,7 +1894,11 @@ export const fileIcons: FileIcons = {
       fileNames: ['vagrantfile'],
       fileExtensions: ['vagrantfile'],
     },
-    { name: 'prisma', fileNames: ['prisma.yml'], fileExtensions: ['prisma'] },
+    {
+      name: 'prisma',
+      fileNames: ['prisma.yml', 'prisma.config.ts'],
+      fileExtensions: ['prisma'],
+    },
     { name: 'razor', fileExtensions: ['cshtml', 'vbhtml'] },
     { name: 'abc', fileExtensions: ['abc'] },
     { name: 'asciidoc', fileExtensions: ['ad', 'adoc', 'asciidoc'] },


### PR DESCRIPTION
# Description

[Prisma](https://www.prisma.io/) is working on a [new config file standard](https://www.prisma.io/docs/orm/reference/prisma-config-reference), still in early access, but the file name should not change. Therefore, I'm adding this newer file name to the existing Prisma files set to use the respective icon.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
