### PR TITLE
fix: correct phpstan icon file patterns

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2856,7 +2856,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'phpstan',
-      fileNames: ['phpstan.neon', 'phpneon.neon.dist'],
+      fileNames: ['phpstan.neon', 'phpstan.neon.dist', 'phpstan.dist.neon'],
     },
     {
       name: 'screwdriver',


### PR DESCRIPTION
# Description

- Fixed typo in PHPStan icon configuration: `'phpneon.neon.dist'` → `'phpstan.neon.dist'`
- Added support for `'phpstan.dist.neon'` file pattern to match PHPStan's official naming convention

According to the [PHPStan documentation](https://phpstan.org/config-reference#config-file), PHPStan looks for configuration files in this priority order:
1. `phpstan.neon` (user override)
2. `phpstan.neon.dist` (distributed config) 
3. `phpstan.dist.neon` (distributed config)

This ensures the icon correctly displays for all standard PHPStan configuration file patterns.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules