### PR TITLE
feat: enhance excalidraw file icon support with additional file names…

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -542,8 +542,18 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'excalidraw',
-      fileNames: ['excalidraw.json', 'excalidraw.svg', 'excalidraw.png'],
-      fileExtensions: ['excalidraw.json', 'excalidraw.svg', 'excalidraw.png'],
+      fileNames: [
+        'excalidraw',
+        'excalidraw.json',
+        'excalidraw.svg',
+        'excalidraw.png',
+      ],
+      fileExtensions: [
+        'excalidraw',
+        'excalidraw.json',
+        'excalidraw.svg',
+        'excalidraw.png',
+      ],
     },
     {
       name: 'gradle',


### PR DESCRIPTION
This pull request includes a small change to the `fileIcons` configuration in `src/core/icons/fileIcons.ts`. The change ensures that the `excalidraw` file type is properly recognized by adding the base name `excalidraw` to both `fileNames` and `fileExtensions`.… and extensions

# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
- follow up for #2995

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
