### PR TITLE
refactor: remove icons for `tex` and `ltx` file extensions

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -771,25 +771,19 @@ export const fileIcons: FileIcons = {
         'compose.worker.yml',
       ],
     },
-    { name: 'bbx', fileExtensions: ['bbx'] },
-    { name: 'cbx', fileExtensions: ['cbx'] },
-    { name: 'lbx', fileExtensions: ['lbx'] },
-    { name: 'tex', fileExtensions: ['tex'] },
     {
       name: 'sty',
       fileExtensions: ['sty'],
       clone: { base: 'tex', color: 'deep-purple-A100' },
     },
     {
-      name: 'ltx',
-      fileExtensions: ['ltx'],
-      clone: { base: 'tex', color: 'teal-A700' },
-    },
-    {
       name: 'dtx',
       fileExtensions: ['dtx'],
       clone: { base: 'tex', color: 'yellow-900' },
     },
+    { name: 'bbx', fileExtensions: ['bbx'] },
+    { name: 'cbx', fileExtensions: ['cbx'] },
+    { name: 'lbx', fileExtensions: ['lbx'] },
     { name: 'latexmk', patterns: { latexmkrc: FileNamePattern.Dotfile } },
     {
       name: 'powerpoint',


### PR DESCRIPTION
# Description

This pull request removes the icon associations for the `.tex` and `.ltx` file extensions to avoid a conflict with the icon assigned to the `latex` language ID.

The issue is that the `.tex` extension is used for both TeX and LaTeX files. However, since an icon was specifically associated with this extension, the icon would always be the same regardless of the language ID.

By removing the icon association from the extension, only the language ID will determine which icon is shown. Since VS Code recognizes the `tex` and `latex` IDs without needing a third-party extension, this should not cause any issues.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.