### PR TITLE
feat: associate `doctex-installer` icon with `.ins` file extension

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -804,6 +804,10 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['dtx'],
       clone: { base: 'tex', color: 'yellow-900' },
     },
+    {
+      name: 'doctex-installer',
+      fileExtensions: ['ins'],
+    },
     { name: 'bbx', fileExtensions: ['bbx'] },
     { name: 'cbx', fileExtensions: ['cbx'] },
     { name: 'lbx', fileExtensions: ['lbx'] },


### PR DESCRIPTION
# Description

This pull request associates the `doctex-installer` icon with the `.ins` file extension. Apparently this extension has no other relevant application, so I believe there will be no conflict.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.