### PR TITLE
feat: associate `context` icon with `.ctx` file extension

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -799,6 +799,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['sty'],
       clone: { base: 'tex', color: 'deep-purple-A100' },
     },
+    { name: 'context', fileExtensions: ['ctx'] },
     {
       name: 'dtx',
       fileExtensions: ['dtx'],


### PR DESCRIPTION
# Description

This pull request associates the `context` icon with the `.ctx` file extension.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.