### PR TITLE
feat: associate `folder-test` icon with `testfiles` folder

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -104,7 +104,15 @@ export const folderIcons: FolderTheme[] = [
       { name: 'folder-bower', folderNames: ['bower_components'] },
       {
         name: 'folder-test',
-        folderNames: ['test', 'tests', 'testing', 'snapshots', 'spec', 'specs'],
+        folderNames: [
+          'test',
+          'tests',
+          'testing',
+          'snapshots',
+          'spec',
+          'specs',
+          'testfiles',
+        ],
       },
       {
         name: 'folder-directive',


### PR DESCRIPTION
# Description

This pull request associates the `folder-test` icon with the `testfiles` folder, which is defined by [l3build](https://ctan.org/pkg/l3build) as the default folder for testing files.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.