### PR TITLE
fix: 🚑 wrong biome json schema in `biome.jsonc`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,


### PR DESCRIPTION
# Description

#3071 upgraded biome to 2.1.1, but `biome.jsonc` is still using the 2.0.0 schema.
This causes the liter to show a warning:

```
$ bun run lint       
$ biome check
biome.jsonc:2:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ! The configuration schema version does not match the CLI version 2.1.1

    1 │ {
  > 2 │   "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 │   "formatter": {
    4 │     "enabled": true,

  i   Expected:                     2.1.1
      Found:                        2.0.0

  i Run the command biome migrate to migrate the configuration file.

Checked 140 files in 112ms. No fixes applied.
Found 1 warning.
```

This PR sets the schema to `2.1.1`.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
