### PR TITLE
feat(fileIcons): add .env.sentry-build-plugin to sentry icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2454,7 +2454,7 @@ export const fileIcons: FileIcons = {
     { name: 'gemini', fileExtensions: ['gmi', 'gemini'] },
     {
       name: 'sentry',
-      fileNames: ['.sentryclirc'],
+      fileNames: ['.sentryclirc', '.env.sentry-build-plugin'],
       patterns: {
         'sentry.client.config': FileNamePattern.Ecmascript,
         'sentry.server.config': FileNamePattern.Ecmascript,


### PR DESCRIPTION
# Description

Adds `.env.sentry-build-plugin` to the list of recognized filenames for the existing Sentry icon.

This file stores authentication credentials and project metadata for use by Sentry’s official build plugins (Webpack, Vite, esbuild, Rollup, and eventually Turbopack once production plugin support is stable) to enable automated source map uploads.

---

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
