### PR TITLE
feat(icons): add support for 'meson.options' file in meson icon mapping

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2240,7 +2240,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'meson',
-      fileNames: ['meson.build', 'meson_options.txt'],
+      fileNames: ['meson.build', 'meson_options.txt', 'meson.options'],
       fileExtensions: ['wrap'],
     },
     {


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

Resolves this PR also for the upstream repo:
https://github.com/zed-extensions/material-icon-theme/pull/36

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
