### PR TITLE
docs: fix translations path

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ We welcome contributions of all kinds! Whether you want to add new icons, improv
   Ready to contribute code or icons? [Create a pull request](https://github.com/material-extensions/vscode-material-icon-theme/pulls).
 
 - 🌍 **Help with Translations**
-  Improve or add translations by editing the files in `src/i18n` and `package.nls.*.json`.
+  Improve or add translations by editing the files in `src/core/i18n/translations/` and `package.nls.*.json`.
 
 ## Related extensions
 


### PR DESCRIPTION
# Description

It appears that the translation files have been moved to `src/core`.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
