### PR TITLE
feat: clone `bashly-hook` icon for Bashly strings file

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3332,6 +3332,18 @@ export const fileIcons: FileIcons = {
       enabledFor: [IconPack.Bashly],
     },
     {
+      name: 'bashly-strings',
+      clone: {
+        base: 'bashly-hook',
+        color: 'gray-300',
+        lightColor: 'gray-800',
+      },
+      patterns: {
+        'src/bashly-strings': FileNamePattern.Yaml,
+      },
+      light: true,
+    },
+    {
       name: 'google',
       fileNames: ['google-services.json', 'GoogleService-Info.plist'],
     },


### PR DESCRIPTION
# Description

This pull request introduces a new icon for the [Bashly strings file](https://bashly.dev/advanced/strings#custom-strings), which is a clone of the [`bashly-hook` icon](https://github.com/material-extensions/vscode-material-icon-theme/blob/962053b2695234e5796cb2b229ca151698e245fe/icons/bashly-hook.svg) and uses the same color configuration as the [`bashly-settings` icon](https://github.com/material-extensions/vscode-material-icon-theme/blob/962053b2695234e5796cb2b229ca151698e245fe/src/core/icons/fileIcons.ts#L3305).

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.