### PR TITLE
feat: improve `console` icon design

### DIFF
--- a/icons/console.svg
+++ b/icons/console.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="#ff7043" d="M2 2a1 1 0 0 0-1 1v10c0 .554.446 1 1 1h12c.554 0 1-.446 1-1V3a1 1 0 0 0-1-1zm0 3h12v8H2zm1 1 3 3-3 3h2l3-3-3-3zm5 4.5V12h5v-1.5z"/></svg>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill="#ff7043" d="M2 2a1 1 0 00-1 1v10c0 .554.446 1 1 1h12c.554 0 1-.446 1-1V3a1 1 0 00-1-1zm0 3h12v8H2zm1 2l2 2-2 2 1 1 3-3-3-3zm5 3.5V12h5v-1.5z"/></svg>


### PR DESCRIPTION
# Description

This pull request proposes ~an improvement~ a small adjustment to the [`console` icon](https://github.com/material-extensions/vscode-material-icon-theme/blob/8bef59d5b65d1ed57b4fc43aacea7c94f3b64c3c/icons/console.svg). As you can see in the [comparison](https://github.com/material-extensions/vscode-material-icon-theme/commit/8bef59d5b65d1ed57b4fc43aacea7c94f3b64c3c#diff-3bf2caa700db3eb8b992e251e733caeaf3f72df66a64d3f02e51144620a8ea09), the prompt in the new icon has trimmed ends and was slightly shifted to the left to compensate for the difference in width, enhancing the spacing between the two shapes inside the frame and giving the icon a clearer appearance.

In fact, [the same icon in the Material Design catalog](https://fonts.google.com/icons?selected=Material+Symbols+Outlined:terminal:wght@400) shares these shapes, which justifies this adjustment. When I previously proposed the current icon in #3175, I hadn’t checked the official one.

Since this proposal is somewhat subjective, I’d suggest you take a look and decide whether it’s worth merging. Either way, I’m happy to contribute.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.