### PR TITLE
Added filepaths to support the .config directory proposal ahead of time (adopted by prisma)

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1959,7 +1959,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'prisma',
-      fileNames: ['prisma.yml', 'prisma.config.ts'],
+      fileNames: ['prisma.yml', 'prisma.config.ts', '.config/prisma.ts'],
       fileExtensions: ['prisma'],
     },
     { name: 'razor', fileExtensions: ['cshtml', 'vbhtml'] },

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -76,6 +76,26 @@ export const fileIcons: FileIcons = {
         'playwright-ct.config.ts',
         'playwright-ct.config.cts',
         'playwright-ct.config.mts',
+
+        // support for .config/[name].[ext] proposal
+        'playwright.config.js',
+        'playwright.config.cjs',
+        'playwright.config.mjs',
+        'playwright.config.ts',
+        'playwright.config.cts',
+        'playwright.config.mts',
+        'playwright.config.base.js',
+        'playwright.config.base.cjs',
+        'playwright.config.base.mjs',
+        'playwright.config.base.ts',
+        'playwright.config.base.cts',
+        'playwright.config.base.mts',
+        'playwright-ct.config.js',
+        'playwright-ct.config.cjs',
+        'playwright-ct.config.mjs',
+        'playwright-ct.config.ts',
+        'playwright-ct.config.cts',
+        'playwright-ct.config.mts',
       ],
     },
     {
@@ -351,6 +371,14 @@ export const fileIcons: FileIcons = {
     {
       name: 'astro-config',
       fileNames: [
+        'astro.config.js',
+        'astro.config.mjs',
+        'astro.config.cjs',
+        'astro.config.ts',
+        'astro.config.cts',
+        'astro.config.mts',
+
+        // support for .config/[name].[ext] proposal
         'astro.config.js',
         'astro.config.mjs',
         'astro.config.cjs',
@@ -657,6 +685,8 @@ export const fileIcons: FileIcons = {
         'keystatic.config.ts',
         'keystatic.config.jsx',
         'keystatic.config.js',
+
+        // support for .config/[name].[ext] proposal
       ],
     },
     {
@@ -1959,8 +1989,11 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'prisma',
-      fileNames: ['prisma.yml', 'prisma.config.ts', '.config/prisma.ts'],
+      fileNames: ['prisma.yml', 'prisma.config.ts'],
       fileExtensions: ['prisma'],
+      patterns: {
+        prisma: FileNamePattern.DotConfigDirectory,
+      }
     },
     { name: 'razor', fileExtensions: ['cshtml', 'vbhtml'] },
     { name: 'abc', fileExtensions: ['abc'] },

--- a/src/core/models/icons/patterns/patterns.ts
+++ b/src/core/models/icons/patterns/patterns.ts
@@ -18,6 +18,17 @@ export enum FileNamePattern {
 
   /** It adjusts the name with the following patterns: `.${fileName}`, `${fileName}`. */
   Dotfile = 'dotfile',
+
+  /**
+   * @description
+   * It adjusts the name with the following patterns: `.config/${fileName}`, `${fileName}`.
+   *
+   * This is to support the proposed standard for configuration files to be placed in a `.config` directory.
+   * See the following links for more information:
+   * @see {@link https://github.com/pi0/config-dir}
+   * @see {@link https://www.prisma.io/docs/orm/reference/prisma-config-reference#supported-file-extensions}
+   * */
+  DotConfigDirectory = 'dotConfigDirectory',
 }
 
 export type Patterns = Record<string, FileNamePattern>;

--- a/src/core/patterns/patterns.ts
+++ b/src/core/patterns/patterns.ts
@@ -99,6 +99,22 @@ const mapPatterns = (patterns: Patterns): string[] => {
       case FileNamePattern.Dotfile:
         return [`.${fileName}`, fileName];
 
+      case FileNamePattern.DotConfigDirectory:
+        return [
+          `.config/${fileName}.json`,
+          `.config/${fileName}.jsonc`,
+          `.config/${fileName}.json5`,
+          `.config/${fileName}.yaml`,
+          `.config/${fileName}.yml`,
+          `.config/${fileName}.toml`,
+          `.config/${fileName}.js`,
+          `.config/${fileName}.mjs`,
+          `.config/${fileName}.cjs`,
+          `.config/${fileName}.ts`,
+          `.config/${fileName}.mts`,
+          `.config/${fileName}.cts`,
+        ];
+
       default:
         // Check if all potential pattern cases are handled
         const exhaustiveCheck: never = pattern;


### PR DESCRIPTION
# Description

I've added file paths to the prisma icon because i found that some files don't match with the current configured file paths.

As stated in the documentation page provided below:

"Prisma Config files can be named as `prisma.config.*` or `.config/prisma.*` with the extensions `js`, `ts`, `mjs`, `cjs`, `mts`, or `cts`. Other extensions are supported to ensure compatibility with different TypeScript compiler settings."

Recommendation

Use `prisma.config.ts` for small TypeScript projects.
Use `.config/prisma.ts` for larger TypeScript projects with multiple configuration files [(following the .config directory proposal)](https://github.com/pi0/config-dir).

https://www.prisma.io/docs/orm/reference/prisma-config-reference#supported-file-extensions


## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
