### PR TITLE
feat: made the icon for `blog/` the same as `news/`

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -142,6 +142,7 @@ export const folderIcons: FolderTheme[] = [
           'articles',
           'wiki',
           'news',
+          'blog',
         ],
       },
       { name: 'folder-gh-workflows', folderNames: ['github/workflows'] },


### PR DESCRIPTION
# Description

Made the icon for `blog/` the same as `news/`

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
