### PR TITLE
fix: Add 'jsonl' to languageIcons

### DIFF
--- a/src/core/icons/languageIcons.ts
+++ b/src/core/icons/languageIcons.ts
@@ -21,7 +21,7 @@ export const languageIcons: LanguageIcon[] = [
   },
   { name: 'toml', light: true, ids: ['toml'] },
   { name: 'diff', ids: ['diff'] },
-  { name: 'json', ids: ['json', 'jsonc', 'json5'] },
+  { name: 'json', ids: ['json', 'jsonl', 'jsonc', 'json5'] },
   { name: 'blink', ids: ['blink'] },
   { name: 'java', ids: ['java'] },
   { name: 'razor', ids: ['razor', 'aspnetcorerazor'] },


### PR DESCRIPTION
# Description
Added `'jsonl'` to /src/core/icons/languageIcons.ts so that it shows the JSON icon instead of the generic file icon when creating a new JSONL file and so it shows up in the Select Language box

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
