### PR TITLE
feat: Image icon for KTX and KTX2 files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -206,6 +206,8 @@ export const fileIcons: FileIcons = {
         'srf',
         'srw',
         'x3f',
+        'ktx',
+        'ktx2',
       ],
     },
     { name: 'palette', fileExtensions: ['pal', 'gpl', 'act'] },


### PR DESCRIPTION
# Description

KTX and KTX2 are texture assets format created by the Khronos Group.

According to the specs, the file extensions are `.ktx` and `.ktx2` respectively.

https://registry.khronos.org/KTX/specs/1.0/ktxspec.v1.html
https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
