### PR TITLE
feat: add support for `vitest.unit.config` and `vitest.e2e.config` file patterns

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2445,6 +2445,8 @@ export const fileIcons: FileIcons = {
       patterns: {
         'vitest.workspace': FileNamePattern.Ecmascript,
         'vitest.config': FileNamePattern.Ecmascript,
+        'vitest.unit.config': FileNamePattern.Ecmascript,
+        'vitest.e2e.config': FileNamePattern.Ecmascript,
       },
     },
     {


### PR DESCRIPTION
# Description

Add two file patterns `vitest.unit.config` and `vitest.e2e.config` for Vitest configuration.

Names taken from the [official documentation](https://vitest.dev/guide/projects.html#defining-projects).

Ideally it would match all `vitest.*.config.ts` but it's blocked by #330.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
