### PR TITLE
feat(swift): extend Swift file icon mappings

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -700,8 +700,15 @@ export const fileIcons: FileIcons = {
     { name: 'fsharp', fileExtensions: ['fs', 'fsx', 'fsi', 'fsproj'] },
     {
       name: 'swift',
-      fileExtensions: ['swift'],
-      fileNames: ['.swift-format', '.swift-version'],
+      fileExtensions: [
+        'swift',
+        'xcplayground',
+        'swiftdeps',
+        'swiftdoc',
+        'swiftmodule',
+        'swiftsourceinfo',
+      ],
+      fileNames: ['.swift-format', '.swift-version', '.swiftformat'],
     },
     { name: 'arduino', fileExtensions: ['ino'] },
     {


### PR DESCRIPTION
# Description

This PR adds common Swift file icon mappings.

**New filenames**

* `.swiftformat` *(config for the community [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) tool, an alternative to Xcode’s native `SwiftFormat` tool which uses `.swift-format` for its config)*

**New extensions**

* `xcplayground`
* `swiftdeps`
* `swiftdoc`
* `swiftmodule`
* `swiftsourceinfo`

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
