### PR TITLE
feat: Add 'terraformignore' file extension to terraform icon configuration

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1310,7 +1310,14 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'terraform',
-      fileExtensions: ['tf', 'tf.json', 'tfvars', 'tfstate', 'tfbackend'],
+      fileExtensions: [
+        'tf',
+        'tf.json',
+        'tfvars',
+        'tfstate',
+        'tfbackend',
+        'terraformignore',
+      ],
     },
     {
       name: 'opentofu',


### PR DESCRIPTION
# Description

Added `terraformignore` to terraform icon configuration 

Fixes: #3304

<!-- Please describe in a short sentence or bullet points what changes you have made. -->
- Added 'terraformignore' as a recognized file extension for the terraform icon configuration.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules

