### PR TITLE
chore(.gitignore): .vscode/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist
 # Ignore node_modules directory
 node_modules
 
+# Ignore user .vscode settings
+.vscode/*
+
 # Ignore VS Code test files
 .vscode-test/**
 *.vsix


### PR DESCRIPTION
# Description
Avoid having `.vscode` folder changes being tracked.

## Why?
Some vscode extension that are running automatically, it would be nice if they would be ignored while contributing to this repo

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
