### PR TITLE
feat: Include `benches` folder in the `folder-benchmark` for Rust's conventional benchmark directory

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -1373,5 +1373,4 @@ export const folderIcons: FolderTheme[] = [
     rootFolder: { name: 'folder-root' },
   },
   { name: 'none', defaultIcon: { name: '' } },
-
 ];


### PR DESCRIPTION
# Description

[Following the recommended Rust project structure](https://doc.rust-lang.org/cargo/guide/project-layout.html), the `benches` directory contains the benchmarking code for a crate. This is currently not correctly listed as a special folder for this plugin:

<img width="301" height="113" alt="image" src="https://github.com/user-attachments/assets/7b5c4c26-266c-47fb-be6b-714213187bd8" />

On top of this, `benches` is becoming a more commonly used directory across many languages to hold benchmarking code.

This pull requests does not add any additional icons to the repository, only adding  `benches` as a new member of `folder-benchmark` within `folderIcons.ts`.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules

---

I apologise if my pull request doesn't follow the conventions or rules stated in your repository. I rarely make pull requests and am not certain if this is correct, so please let me know if it isn’t. I’m always open to learning.