### PR TITLE
fix: add wixproj to visualstudio file extensions

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -398,6 +398,7 @@ export const fileIcons: FileIcons = {
         'vcxitems.filters',
         'vcxproj',
         'vcxproj.filters',
+        'wixproj',
       ],
       fileNames: ['.vsconfig'],
     },


### PR DESCRIPTION
# Description

Adds [`wixproj`](https://docs.firegiant.com/wix3/msbuild/authoring_first_msbuild_project) to `visualstudio` file extensions, which is used by the [WiX Toolset](https://docs.firegiant.com/wix/):
> In order to build WiX using MSBuild, a .wixproj file must be created. The easiest way to create a new .wixproj for your installer is to [use] WiX in Visual Studio because it automatically generates standard msbuild project files ...

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
