### PR TITLE
feat(icon): File and folder icons for Postgraphile

### DIFF
--- a/icons/folder-postgraphile-open.svg
+++ b/icons/folder-postgraphile-open.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 32 32" version="1.1" id="svg2" xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg">
+  <path fill="#0288d1"
+    d="M28.967 12H9.442a2 2 0 0 0-1.898 1.368L4 24V10h24a2 2 0 0 0-2-2H15.124a2 2 0 0 1-1.28-.464l-1.288-1.072A2 2 0 0 0 11.276 6H4a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h22l4.805-11.212A2 2 0 0 0 28.967 12"
+    id="path1" />
+  <g style="stroke-width:0;shape-rendering:geometricPrecision" id="g1" transform="matrix(0.016,0,0,0.016,12.5,10.5)">
+    <g class="ears" id="g10">
+      <path fill="#e1f5fe" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
+      <path fill="#e1f5fe" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2-1" />
+      <path fill="#e1f5fe" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
+      <path fill="#e1f5fe" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
+      <path fill="#e1f5fe" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
+      <path fill="#e1f5fe" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
+      <path fill="#e1f5fe" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
+      <path fill="#e1f5fe" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
+      <path fill="#e1f5fe" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
+      <path fill="none" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15"
+        d="M 25,360 260,25 v 0 l 340,105 v 0 L 940,25 v 0 l 235,335 v 0 l -75,255 v 0 l -500,440 v 0 L 100,615 v 0 z"
+        class="heart-outline" id="path10" />
+    </g>
+    <g class="face" id="g26">
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
+        class="tusk left-tusk" id="path11" />
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
+        class="tusk right-tusk" id="path12" />
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
+        class="tusk left-tusk" id="path13" />
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
+        class="tusk right-tusk" id="path14" />
+      <path fill="#e1f5fe" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
+      <path fill="#e1f5fe" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
+      <path fill="#e1f5fe" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
+      <path fill="#e1f5fe" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
+      <path fill="#e1f5fe" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
+        id="path19" />
+      <path fill="#e1f5fe" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
+        id="path20" />
+      <path fill="#e1f5fe" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
+        id="path21" />
+      <path fill="#e1f5fe" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
+        id="path22" />
+      <path fill="#e1f5fe" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
+      <path fill="none" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="30"
+        d="M 490,96 H 710 L 875,300 V 725 L 710,835 v 240 l -110,55 -110,-55 V 835 L 325,725 V 300 Z"
+        class="entire-face stroke-only" id="path24" />
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
+        id="path25" />
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
+        id="path26" />
+    </g>
+  </g>
+</svg>

--- a/icons/folder-postgraphile.svg
+++ b/icons/folder-postgraphile.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 32 32" version="1.1" id="svg2" xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg">
+  <path fill="#0288d1"
+    d="m13.844 7.536-1.288-1.072A2 2 0 0 0 11.276 6H4a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h24a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2H15.124a2 2 0 0 1-1.28-.464"
+    id="path1" />
+  <g style="stroke-width:0;shape-rendering:geometricPrecision" id="g1" transform="matrix(0.016,0,0,0.016,12.5,10.5)">
+    <g class="ears" id="g10">
+      <path fill="#e1f5fe" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
+      <path fill="#e1f5fe" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2-1" />
+      <path fill="#e1f5fe" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
+      <path fill="#e1f5fe" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
+      <path fill="#e1f5fe" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
+      <path fill="#e1f5fe" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
+      <path fill="#e1f5fe" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
+      <path fill="#e1f5fe" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
+      <path fill="#e1f5fe" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
+      <path fill="none" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15"
+        d="M 25,360 260,25 v 0 l 340,105 v 0 L 940,25 v 0 l 235,335 v 0 l -75,255 v 0 l -500,440 v 0 L 100,615 v 0 z"
+        class="heart-outline" id="path10" />
+    </g>
+    <g class="face" id="g26">
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
+        class="tusk left-tusk" id="path11" />
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
+        class="tusk right-tusk" id="path12" />
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
+        class="tusk left-tusk" id="path13" />
+      <path fill="#fafafa" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
+        class="tusk right-tusk" id="path14" />
+      <path fill="#e1f5fe" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
+      <path fill="#e1f5fe" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
+      <path fill="#e1f5fe" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
+      <path fill="#e1f5fe" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
+      <path fill="#e1f5fe" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
+        id="path19" />
+      <path fill="#e1f5fe" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
+        id="path20" />
+      <path fill="#e1f5fe" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
+        id="path21" />
+      <path fill="#e1f5fe" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
+        id="path22" />
+      <path fill="#e1f5fe" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
+      <path fill="none" stroke="#4fc3f7" stroke-linejoin="round" stroke-width="30"
+        d="M 490,96 H 710 L 875,300 V 725 L 710,835 v 240 l -110,55 -110,-55 V 835 L 325,725 V 300 Z"
+        class="entire-face stroke-only" id="path24" />
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
+        id="path25" />
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
+        id="path26" />
+    </g>
+  </g>
+</svg>

--- a/icons/postgraphile-js.svg
+++ b/icons/postgraphile-js.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xml:space="preserve" viewBox="0 0 16 16" version="1.1" id="svg1" xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg">
+  <g style="stroke-width:0;shape-rendering:geometricPrecision" id="g1"
+    transform="matrix(0.01229036,0,0,0.01229036,0.625784,0.85622855)">
+    <g class="ears" id="g10">
+      <path fill="#dcaa33" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
+      <path fill="#fec949" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2" />
+      <path fill="#dcaa33" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
+      <path fill="#dcaa33" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
+      <path fill="#fec949" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
+      <path fill="#dcaa33" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
+      <path fill="#dcaa33" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
+      <path fill="#dcaa33" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
+      <path fill="#dcaa33" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
+      <path fill="none" stroke="#473302" stroke-linejoin="round" stroke-width="15"
+        d="M 25,360 260,25 v 0 l 340,105 v 0 L 940,25 v 0 l 235,335 v 0 l -75,255 v 0 l -500,440 v 0 L 100,615 v 0 z"
+        class="heart-outline" id="path10" />
+    </g>
+    <g class="face" id="g26">
+      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
+        class="tusk left-tusk" id="path11" />
+      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
+        class="tusk right-tusk" id="path12" />
+      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
+        class="tusk left-tusk" id="path13" />
+      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
+        class="tusk right-tusk" id="path14" />
+      <path fill="#fec949" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
+      <path fill="#dcaa33" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
+      <path fill="#cb8c06" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
+      <path fill="#875c00" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
+      <path fill="#654904" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
+        id="path19" />
+      <path fill="#cb8c06" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
+        id="path20" />
+      <path fill="#fec949" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
+        id="path21" />
+      <path fill="#cb8c06" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
+        id="path22" />
+      <path fill="#dcaa33" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
+      <path fill="none" stroke="#473302" stroke-linejoin="round" stroke-width="30"
+        d="M 490,96 H 710 L 875,300 V 725 L 710,835 v 240 l -110,55 -110,-55 V 835 L 325,725 V 300 Z"
+        class="entire-face stroke-only" id="path24" />
+      <path fill="#feffff" stroke="#feffff" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
+        id="path25" />
+      <path fill="#feffff" stroke="#feffff" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
+        id="path26" />
+    </g>
+  </g>
+</svg>

--- a/icons/postgraphile-js.svg
+++ b/icons/postgraphile-js.svg
@@ -4,47 +4,47 @@
   <g style="stroke-width:0;shape-rendering:geometricPrecision" id="g1"
     transform="matrix(0.01229036,0,0,0.01229036,0.625784,0.85622855)">
     <g class="ears" id="g10">
-      <path fill="#dcaa33" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
-      <path fill="#fec949" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2" />
-      <path fill="#dcaa33" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
-      <path fill="#dcaa33" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
-      <path fill="#fec949" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
-      <path fill="#dcaa33" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
-      <path fill="#dcaa33" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
-      <path fill="#dcaa33" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
-      <path fill="#dcaa33" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
-      <path fill="none" stroke="#473302" stroke-linejoin="round" stroke-width="15"
+      <path fill="#fbc02d" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
+      <path fill="#ffca28" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2" />
+      <path fill="#fbc02d" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
+      <path fill="#fbc02d" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
+      <path fill="#ffca28" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
+      <path fill="#fbc02d" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
+      <path fill="#fbc02d" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
+      <path fill="#fbc02d" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
+      <path fill="#fbc02d" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
+      <path fill="none" stroke="#4e342e" stroke-linejoin="round" stroke-width="15"
         d="M 25,360 260,25 v 0 l 340,105 v 0 L 940,25 v 0 l 235,335 v 0 l -75,255 v 0 l -500,440 v 0 L 100,615 v 0 z"
         class="heart-outline" id="path10" />
     </g>
     <g class="face" id="g26">
-      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
+      <path fill="#fafafa" stroke="#4e342e" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
         class="tusk left-tusk" id="path11" />
-      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
+      <path fill="#fafafa" stroke="#4e342e" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
         class="tusk right-tusk" id="path12" />
-      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
+      <path fill="#fafafa" stroke="#4e342e" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
         class="tusk left-tusk" id="path13" />
-      <path fill="#feffff" stroke="#473302" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
+      <path fill="#fafafa" stroke="#4e342e" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
         class="tusk right-tusk" id="path14" />
-      <path fill="#fec949" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
-      <path fill="#dcaa33" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
-      <path fill="#cb8c06" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
-      <path fill="#875c00" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
-      <path fill="#654904" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
+      <path fill="#ffca28" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
+      <path fill="#fbc02d" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
+      <path fill="#f9a825" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
+      <path fill="#ffa726" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
+      <path fill="#ff9800" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
         id="path19" />
-      <path fill="#cb8c06" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
+      <path fill="#f9a825" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
         id="path20" />
-      <path fill="#fec949" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
+      <path fill="#ffca28" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
         id="path21" />
-      <path fill="#cb8c06" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
+      <path fill="#f9a825" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
         id="path22" />
-      <path fill="#dcaa33" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
-      <path fill="none" stroke="#473302" stroke-linejoin="round" stroke-width="30"
+      <path fill="#fbc02d" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
+      <path fill="none" stroke="#4e342e" stroke-linejoin="round" stroke-width="30"
         d="M 490,96 H 710 L 875,300 V 725 L 710,835 v 240 l -110,55 -110,-55 V 835 L 325,725 V 300 Z"
         class="entire-face stroke-only" id="path24" />
-      <path fill="#feffff" stroke="#feffff" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
         id="path25" />
-      <path fill="#feffff" stroke="#feffff" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
         id="path26" />
     </g>
   </g>

--- a/icons/postgraphile.svg
+++ b/icons/postgraphile.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xml:space="preserve" viewBox="0 0 16 16" version="1.1" id="svg1" xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg">
+  <g style="stroke-width:0;shape-rendering:geometricPrecision" id="g1"
+    transform="matrix(0.01229036,0,0,0.01229036,0.625784,0.85622855)">
+    <g class="ears" id="g10">
+      <path fill="#468bcc" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
+      <path fill="#4ba8ff" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2" />
+      <path fill="#468bcc" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
+      <path fill="#468bcc" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
+      <path fill="#4ba8ff" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
+      <path fill="#468bcc" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
+      <path fill="#468bcc" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
+      <path fill="#468bcc" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
+      <path fill="#468bcc" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
+      <path fill="none" stroke="#082744" stroke-linejoin="round" stroke-width="15"
+        d="M 25,360 260,25 v 0 l 340,105 v 0 L 940,25 v 0 l 235,335 v 0 l -75,255 v 0 l -500,440 v 0 L 100,615 v 0 z"
+        class="heart-outline" id="path10" />
+    </g>
+    <g class="face" id="g26">
+      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
+        class="tusk left-tusk" id="path11" />
+      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
+        class="tusk right-tusk" id="path12" />
+      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
+        class="tusk left-tusk" id="path13" />
+      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
+        class="tusk right-tusk" id="path14" />
+      <path fill="#4ba8ff" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
+      <path fill="#468bcc" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
+      <path fill="#166ebf" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
+      <path fill="#0b457f" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
+      <path fill="#0c3861" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
+        id="path19" />
+      <path fill="#166ebf" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
+        id="path20" />
+      <path fill="#4ba8ff" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
+        id="path21" />
+      <path fill="#166ebf" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
+        id="path22" />
+      <path fill="#468bcc" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
+      <path fill="none" stroke="#082744" stroke-linejoin="round" stroke-width="30"
+        d="M 490,96 H 710 L 875,300 V 725 L 710,835 v 240 l -110,55 -110,-55 V 835 L 325,725 V 300 Z"
+        class="entire-face stroke-only" id="path24" />
+      <path fill="#ffffff" stroke="#ffffff" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
+        id="path25" />
+      <path fill="#ffffff" stroke="#ffffff" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
+        id="path26" />
+    </g>
+  </g>
+</svg>

--- a/icons/postgraphile.svg
+++ b/icons/postgraphile.svg
@@ -4,47 +4,47 @@
   <g style="stroke-width:0;shape-rendering:geometricPrecision" id="g1"
     transform="matrix(0.01229036,0,0,0.01229036,0.625784,0.85622855)">
     <g class="ears" id="g10">
-      <path fill="#468bcc" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
-      <path fill="#4ba8ff" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2" />
-      <path fill="#468bcc" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
-      <path fill="#468bcc" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
-      <path fill="#4ba8ff" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
-      <path fill="#468bcc" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
-      <path fill="#468bcc" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
-      <path fill="#468bcc" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
-      <path fill="#468bcc" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
-      <path fill="none" stroke="#082744" stroke-linejoin="round" stroke-width="15"
+      <path fill="#1e88e5" d="M 100,615 25,360 260,25 715,615 Z" class="seg1" id="path1-9" />
+      <path fill="#42a5f5" d="M 25,360 260,25 600,130 715,615 Z" class="seg2" id="path2" />
+      <path fill="#1e88e5" d="M 260,25 600,130 940,25 715,615 Z" class="seg1" id="path3" />
+      <path fill="#1e88e5" d="M 600,130 940,25 1175,360 715,615 Z" class="seg1" id="path4" />
+      <path fill="#42a5f5" d="m 940,25 235,335 -75,255 H 715 Z" class="seg2" id="path5" />
+      <path fill="#1e88e5" d="M 1175,360 1100,615 600,1055 715,615 Z" class="seg1" id="path6" />
+      <path fill="#1e88e5" d="M 1100,615 600,1055 100,615 h 615 z" class="seg1" id="path7" />
+      <path fill="#1e88e5" d="M 600,1055 100,615 25,360 715,615 Z" class="seg1" id="path8" />
+      <path fill="#1e88e5" d="M 100,615 25,360 715,615 Z" class="seg1" id="path9" />
+      <path fill="none" stroke="#212121" stroke-linejoin="round" stroke-width="15"
         d="M 25,360 260,25 v 0 l 340,105 v 0 L 940,25 v 0 l 235,335 v 0 l -75,255 v 0 l -500,440 v 0 L 100,615 v 0 z"
         class="heart-outline" id="path10" />
     </g>
     <g class="face" id="g26">
-      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
+      <path fill="#fafafa" stroke="#212121" stroke-linejoin="round" stroke-width="15" d="m 375,740 85,55 -135,105 z"
         class="tusk left-tusk" id="path11" />
-      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
+      <path fill="#fafafa" stroke="#212121" stroke-linejoin="round" stroke-width="15" d="m 825,740 -85,55 135,105 z"
         class="tusk right-tusk" id="path12" />
-      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
+      <path fill="#fafafa" stroke="#212121" stroke-linejoin="round" stroke-width="15" d="M 365,730 470,805 285,950 Z"
         class="tusk left-tusk" id="path13" />
-      <path fill="#ffffff" stroke="#082744" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
+      <path fill="#fafafa" stroke="#212121" stroke-linejoin="round" stroke-width="15" d="M 835,730 730,805 915,950 Z"
         class="tusk right-tusk" id="path14" />
-      <path fill="#4ba8ff" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
-      <path fill="#468bcc" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
-      <path fill="#166ebf" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
-      <path fill="#0b457f" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
-      <path fill="#0c3861" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
+      <path fill="#42a5f5" d="M 325,300 490,96 H 710 L 600,450 Z" class="seg2 forehead-left" id="path15" />
+      <path fill="#1e88e5" d="M 490,96 H 710 L 875,300 600,450 Z" class="seg1 forehead-top" id="path16" />
+      <path fill="#1565c0" d="M 710,96 875,300 V 725 L 600,450 Z" class="seg3 forehead-right no-stroke" id="path17" />
+      <path fill="#0d47a1" d="M 875,300 V 725 L 710,835 600,450 Z" class="seg4 right-eye-area no-stroke" id="path18" />
+      <path fill="#303f9f" d="M 875,725 710,835 600,1130 V 450 Z" class="seg5 face-bottom-right no-stroke"
         id="path19" />
-      <path fill="#166ebf" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
+      <path fill="#1565c0" d="m 710,835 v 240 L 600,1130 490,835 600,450 Z" class="seg3 no-stroke trunk-highlight-right"
         id="path20" />
-      <path fill="#4ba8ff" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
+      <path fill="#42a5f5" d="M 600,1130 490,1075 V 835 L 325,725 600,450 Z" class="seg2 no-stroke trunk-highlight-left"
         id="path21" />
-      <path fill="#166ebf" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
+      <path fill="#1565c0" d="M 490,835 325,725 V 300 l 275,150 z" class="seg3 face-bottom-left no-stroke"
         id="path22" />
-      <path fill="#468bcc" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
-      <path fill="none" stroke="#082744" stroke-linejoin="round" stroke-width="30"
+      <path fill="#1e88e5" d="M 325,725 V 300 l 275,150 z" class="seg1 left-eye-area no-stroke" id="path23" />
+      <path fill="none" stroke="#212121" stroke-linejoin="round" stroke-width="30"
         d="M 490,96 H 710 L 875,300 V 725 L 710,835 v 240 l -110,55 -110,-55 V 835 L 325,725 V 300 Z"
         class="entire-face stroke-only" id="path24" />
-      <path fill="#ffffff" stroke="#ffffff" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 385,415 130,40 -130,50 z" class="eye left-eye"
         id="path25" />
-      <path fill="#ffffff" stroke="#ffffff" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
+      <path fill="#fafafa" stroke="#fafafa" stroke-width="20" d="m 815,415 -130,40 130,50 z" class="eye right-eye"
         id="path26" />
     </g>
   </g>

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3360,6 +3360,19 @@ export const fileIcons: FileIcons = {
       ],
     },
     {
+      name: 'postgraphile',
+      fileNames: ['graphile.config.ts', 'postgraphile.config.ts'],
+    },
+    {
+      name: 'postgraphile-js',
+      fileNames: [
+        'graphile.config.js',
+        'graphile.config.mjs',
+        'postgraphile.config.js',
+        'postgraphile.config.mjs',
+      ],
+    },
+    {
       name: 'bashly',
       patterns: {
         'src/bashly': FileNamePattern.Yaml,

--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -1356,6 +1356,15 @@ export const folderIcons: FolderTheme[] = [
         folderNames: ['metro'],
       },
       {
+        name: 'folder-postgraphile',
+        folderNames: [
+          'graphile',
+          'graphile-plugins',
+          'postgraphile',
+          'postgraphile-plugins',
+        ],
+      },
+      {
         name: 'folder-filter',
         folderNames: ['filter', 'filters'],
       },


### PR DESCRIPTION
# Description

## TLDR:

This pull request adds file and folder icons for common Postgraphile files and folders.

### Context: What is PostGraphile?

Postgraphile is a library for quickly generating GraphQL APIs based on a PostgreSQL database. It currently has [12.9k GitHub stars](https://github.com/graphile/crystal) and has just entered beta testing for its long-awaited v5. It's part of the overall [Graphile](https://github.com/graphile) project, which is a set of tools for working with PostgreSQL to create performant GraphQL APIs.

### Contribution details

As part of this PR, I have:
- Re-colored the original Postgraphile [logo](https://www.graphile.org/static/postgres_postgraphile_graphql-4b238552d875fe06196ba3bda74c6d2b.png) from the [Postgraphile website](https://www.graphile.org/postgraphile/) to fit the Material Color scheme, as defined PKief's [Material Color Converter](https://pkief.github.io/material-color-converter/) tool.
- Also made a yellow version of the logo for vanilla JavaScript files.
- Made a folder icon, using the SVG for TypeScript folders as a template.

I also confirm that I have run `bunx lint-staged` in the repo and that all linting stages have passed.

---

Thank you very much for your time and this wonderful library! And I hope my new icons can be accepted 🙂

---

## Contribution Guidelines

- [X] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [X] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
