### PR TITLE
feat: added gitea workflows icon

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -151,7 +151,7 @@ export const folderIcons: FolderTheme[] = [
         ],
       },
       { name: 'folder-gh-workflows', folderNames: ['github/workflows'] },
-      {  
+      {
         name: 'folder-gitea-workflows',
         folderNames: ['gitea/workflows'],
         clone: {

--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -151,6 +151,14 @@ export const folderIcons: FolderTheme[] = [
         ],
       },
       { name: 'folder-gh-workflows', folderNames: ['github/workflows'] },
+      {  
+        name: 'folder-gitea-workflows',
+        folderNames: ['gitea/workflows'],
+        clone: {
+          base: 'folder-gh-workflows',
+          color: 'light-green-700',
+        },
+      },
       {
         name: 'folder-git',
         folderNames: ['git', 'patches', 'githooks', 'submodules'],


### PR DESCRIPTION
# Description
I've added a Gitea Workflows folder icon, as [Gitea supports workflows and actions](https://docs.gitea.com/usage/actions/quickstart) like Github. It clones the Github workflows folder icon but assigns the color the Gitea folder icon has, to be consistent with how Github's icons are colored the same.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
