### PR TITLE
feat: Add support for vercel.ts icon (typed Vercel configuration)

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1266,7 +1266,13 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'vercel',
-      fileNames: ['vercel.json', 'vercel.ts', '.vercelignore', 'now.json', '.nowignore'],
+      fileNames: [
+        'vercel.json',
+        'vercel.ts',
+        '.vercelignore',
+        'now.json',
+        '.nowignore',
+      ],
       light: true,
     },
     {

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1266,7 +1266,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'vercel',
-      fileNames: ['vercel.json', "vercel.ts", '.vercelignore', 'now.json', '.nowignore'],
+      fileNames: ['vercel.json', 'vercel.ts', '.vercelignore', 'now.json', '.nowignore'],
       light: true,
     },
     {

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1266,7 +1266,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'vercel',
-      fileNames: ['vercel.json', '.vercelignore', 'now.json', '.nowignore'],
+      fileNames: ['vercel.json', "vercel.ts", '.vercelignore', 'now.json', '.nowignore'],
       light: true,
     },
     {


### PR DESCRIPTION
# Description
This PR adds support for the vercel.ts configuration file, mapping it to the existing Vercel icon.

Recently, Vercel introduced vercel.ts as a typed alternative to vercel.json, allowing developers to define configuration using TypeScript with type safety and improved DX.
Reference: https://vercel.com/docs/project-configuration/vercel-ts
## Why this change?

- vercel.ts is functionally equivalent to vercel.json, but with TypeScript support
- It is now part of Vercel’s official configuration options
- Currently, vercel.ts files fall back to a generic TypeScript icon
- Adding a dedicated icon improves visual consistency and discoverability

## Proposed behavior

Map the following file:

vercel.ts → use existing Vercel icon (same as vercel.json)

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
