### PR TITLE
feat: support jxl image file type

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -140,6 +140,7 @@ export const fileIcons: FileIcons = {
         'jbig2',
         'jb2',
         'jng',
+        'jxl',
         'jxr',
         'pgf',
         'pic',


### PR DESCRIPTION
Include JPEG XL (`.jxl`) as an image format.

JPEG XL: <https://github.com/libjxl/libjxl>
