### PR TITLE
feat: add folder associations for rust/cargo projects

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -87,7 +87,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-scripts',
-        folderNames: ['script', 'scripts', 'scripting'],
+        folderNames: ['script', 'scripts', 'scripting', 'xtask'],
       },
       {
         name: 'folder-node',
@@ -263,6 +263,7 @@ export const folderIcons: FolderTheme[] = [
           'lib64',
           'external',
           'externals',
+          'crates',
         ],
       },
       {


### PR DESCRIPTION
# Description

Added 2 folder icon associations for Rust projects using the [Cargo Package Manager](https://github.com/rust-lang/cargo).

- Added `crates` under `folder-lib`. The `crates` directory is used to store project-level libraries.
- Added `xtask` under `folder-scripts`. The `xtask` directory is used to store project-level scripts and automations.

Both of these folders are common conventions seen in Rust projects and monorepositories, even being used in the repository of the Cargo Package Manager itself:

- [`crates`](https://github.com/rust-lang/cargo/tree/master/crates)
- [`xtask`](https://medium.com/better-programming/running-rust-tasks-with-xtask-and-xtaskops-a2193e67dc25)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
