### PR TITLE
feat: add support for metro.config.ts icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3632,6 +3632,9 @@ export const fileIcons: FileIcons = {
         'metro.config.cjs',
         'metro.config.mjs',
         'metro.config.json',
+        'metro.config.ts',
+        'metro.config.cts',
+        'metro.config.mts',
       ],
     },
     {


### PR DESCRIPTION
# Description

This PR adds support for the metro.config.ts configuration file, mapping it to the existing metro icon.

Reference: https://github.com/facebook/metro/releases/tag/v0.83.2

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
