### PR TITLE
feat: add hip file extension icon mapping

### DIFF
--- a/icons/hip.svg
+++ b/icons/hip.svg
@@ -1,0 +1,8 @@
+<svg version="1.2" baseProfile="tiny-ps" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1530 1530" width="1530" height="1530">
+	<title>AMD_Logo-svg</title>
+	<style>
+		tspan { white-space:pre }
+		.shp0 { fill: #000000 } 
+	</style>
+	<path id="Layer" class="shp0" d="M431.35 416.39L15.28 0L1530 0L1530 1515.66L1113.92 1099.32L1113.92 416.39L431.35 416.39ZM430.87 499.83L2.49 928.44L2.49 1528.41L602.04 1528.41L1030.39 1099.81L430.87 1099.81L430.87 499.83Z" />
+</svg>

--- a/icons/hip.svg
+++ b/icons/hip.svg
@@ -2,7 +2,7 @@
 	<title>AMD_Logo-svg</title>
 	<style>
 		tspan { white-space:pre }
-		.shp0 { fill: #ED1C24 }
+		.shp0 { fill: #E53935 }
 	</style>
 	<path id="Layer" class="shp0" d="M431.35 416.39L15.28 0L1530 0L1530 1515.66L1113.92 1099.32L1113.92 416.39L431.35 416.39ZM430.87 499.83L2.49 928.44L2.49 1528.41L602.04 1528.41L1030.39 1099.81L430.87 1099.81L430.87 499.83Z" />
 </svg>

--- a/icons/hip.svg
+++ b/icons/hip.svg
@@ -2,7 +2,7 @@
 	<title>AMD_Logo-svg</title>
 	<style>
 		tspan { white-space:pre }
-		.shp0 { fill: #000000 } 
+		.shp0 { fill: #ED1C24 }
 	</style>
 	<path id="Layer" class="shp0" d="M431.35 416.39L15.28 0L1530 0L1530 1515.66L1113.92 1099.32L1113.92 416.39L431.35 416.39ZM430.87 499.83L2.49 928.44L2.49 1528.41L602.04 1528.41L1030.39 1099.81L430.87 1099.81L430.87 499.83Z" />
 </svg>

--- a/icons/hip.svg
+++ b/icons/hip.svg
@@ -1,8 +1,6 @@
-<svg version="1.2" baseProfile="tiny-ps" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1530 1530" width="1530" height="1530">
-	<title>AMD_Logo-svg</title>
-	<style>
-		tspan { white-space:pre }
-		.shp0 { fill: #E53935 }
-	</style>
-	<path id="Layer" class="shp0" d="M431.35 416.39L15.28 0L1530 0L1530 1515.66L1113.92 1099.32L1113.92 416.39L431.35 416.39ZM430.87 499.83L2.49 928.44L2.49 1528.41L602.04 1528.41L1030.39 1099.81L430.87 1099.81L430.87 499.83Z" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="16" version="1.2" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+ <path id="Layer" d="m5 5-4-4h14v14l-4-4v-6zm0 1-4 4v5h5l4-4h-5z" fill="#f44336" stroke-width=".0091625"/>
+
 </svg>

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -616,6 +616,7 @@ export const fileIcons: FileIcons = {
     { name: 'c3', fileExtensions: ['c3'] },
     { name: 'c', fileExtensions: ['c', 'i', 'mi'] },
     { name: 'h', fileExtensions: ['h'] },
+    { name: 'hip', fileExtensions: ['hip'] },
     {
       name: 'cpp',
       fileExtensions: [


### PR DESCRIPTION
# Description

For some context on what [HIP](https://github.com/ROCm/HIP) is:

HIP (Heterogeneous-compute Interface for Portability) is a C++ dialect and runtime API created by AMD for high-performance GPU computing. It is essentially AMD's open-source equivalent to NVIDIA's CUDA.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
