### PR TITLE
feat: add `.cjs` and `.mjs` support for vue.config file

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1311,6 +1311,8 @@ export const fileIcons: FileIcons = {
       name: 'vue-config',
       fileNames: [
         'vue.config.js',
+        'vue.config.cjs',
+        'vue.config.mjs',
         'vue.config.ts',
         'vetur.config.js',
         'vetur.config.ts',


### PR DESCRIPTION
# Description

This PR add `.cjs` and `.mjs` support for vue.config file and mapping it to the existing `vue-config` icon.

Reference: [vue-cli Repository](https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/util/loadFileConfig.js#L10-L15)

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
