### PR TITLE
feat: add document icon for doc.md and docs.md files

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1211,7 +1211,11 @@ export const fileIcons: FileIcons = {
       ],
     },
     { name: 'coffee', fileExtensions: ['coffee', 'cson', 'iced'] },
-    { name: 'document', fileExtensions: ['txt'] },
+    {
+      name: 'document',
+      fileNames: ['doc.md', 'docs.md'],
+      fileExtensions: ['txt', 'doc.md', 'docs.md'],
+    },
     { name: 'lyric', fileExtensions: ['lrc'] },
     {
       name: 'graphql',


### PR DESCRIPTION
# Description

Maps files named `doc.md` / `docs.md`, and the `*.doc.md` / `*.docs.md` extensions, to the existing `document` icon.

Follows the same approach as #3483 (benchmark markdown icon): a markdown-blue (`#42a5f5`) document glyph for documentation-flavored markdown files. Reuses the existing `document` icon rather than adding a new SVG. The more-specific `doc.md`/`docs.md` extension match takes precedence over the generic `.md` markdown mapping (same mechanism as `bench.md`).

- Registered in `fileIcons.ts`:
  - file names: `doc.md`, `docs.md`
  - file extensions: `*.doc.md`, `*.docs.md`

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)