### PR TITLE
feat: add `.cargo` folder icon mapping

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -10,7 +10,7 @@ export const folderIcons: FolderTheme[] = [
     defaultIcon: { name: 'folder' },
     rootFolder: { name: 'folder-root' },
     icons: [
-      { name: 'folder-rust', folderNames: ['rust'] },
+      { name: 'folder-rust', folderNames: ['rust', '.cargo'] },
       {
         name: 'folder-robot',
         folderNames: ['bot', 'bots', 'robot', 'robots', 'agent', 'agents'],


### PR DESCRIPTION
# Description

This pull request adds the `.cargo` folder to `folder-rust`.

The `.cargo` folder is used to store cargo configuration files (https://doc.rust-lang.org/cargo/reference/config.html).

The Cargo/Crates.io team have said that they prefer the use of the Rust logo instead of the Crates logo for any Cargo related features (https://github.com/simple-icons/simple-icons/issues/1485).

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project.
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules.
