### PR TITLE
feat: add `.vscode-test` config file icon mapping

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -473,6 +473,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'vscode',
+      fileNames: ['.vscode-test.js', '.vscode-test.mjs', '.vscode-test.cjs'],
       fileExtensions: [
         'vscodeignore',
         'vsixmanifest',


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

This PR adds the Visual Studio Code extension test CLI configuration file[^1] to the file icon associations for the VS Code icon.

[^1]: https://code.visualstudio.com/api/working-with-extensions/testing-extension#quick-setup-the-test-cli

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
