### PR TITLE
feat(fileIcons): add .env.preprod to tune icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1744,6 +1744,7 @@ export const fileIcons: FileIcons = {
         '.env.e2e',
         '.env.qa',
         '.env.dist',
+        '.env.preprod',
         '.env.prod',
         '.env.production',
         '.env.prod.example',


### PR DESCRIPTION
`.env.preprod` is a widely used name for a pre-production environment file, but it currently falls back to the default file icon while its siblings in the same project get the `tune` icon:

| File | Icon today |
| --- | --- |
| `.env.dev` | `tune` |
| `.env.preprod` | **default** |
| `.env.prod` | `tune` |

The `tune` icon already covers the neighbouring deployment-stage names — `.env.stg`, `.env.stage`, `.env.staging`, `.env.preview` and `.env.uat` — so `.env.preprod` looks like a gap in that set rather than a new category.

### Why the `env` file extension doesn't already cover it

`fileExtensions: ['env']` only matches the single-dot form. For a two-dot name the consumer resolves the filename first and then walks the progressive suffixes, which for `.env.preprod` yields `env.preprod` → `preprod` — bare `env` is never a candidate, since the first split consumes the leading dot and the second skips past `env`. That is why every two-dot variant in this list has to be enumerated explicitly.

### Change

One entry added to the `tune` icon's `fileNames`, placed next to `.env.prod`:

```diff
         '.env.dist',
+        '.env.preprod',
         '.env.prod',
```

- No new SVG — reuses the existing `tune` icon.
- `.env.preprod` is not currently associated with any other icon, so this introduces no conflict.
- No test or snapshot enumerates this list.

### Note

I left `.env.preprod.local` out to keep the change minimal, though the list does carry `.local` variants for `dev`, `qa`, `prod`, `stg`, `staging` and `test` — happy to add it if you'd prefer the set stay symmetric.
