### PR TITLE
feat: add .forge folder icon for ForgeKit projects

### DIFF
--- a/icons/folder-forge.svg
+++ b/icons/folder-forge.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path id="folder" fill="#00acc1" d="m6.922 3.768-.644-.536A1 1 0 0 0 5.638 3H2a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H7.562a1 1 0 0 1-.64-.232"/>
+  <path id="motive" fill="#FF6D00" d="M4 5h1v1H4zm1 1h1v1H5zm2-1h1v1H7zm-1 1h1v1H6zm2 1h1v1H8zM4 12h1v1H4zm3 1h1v1H7zM5 6h1v1H5zm2 1h1v1H7zM8 5h1v1H8zm1 1h1v1H9zm1-1h1v1H9zm1 1h1v1H9zm1 1h1v1H9zm1 1h1v1H9z"/>
+  <path fill="#FFB300" d="M4 9h1v1H4zm1 1h1v1H5zm2-1h1v1H7zm-1 1h1v1H6zm2 1h1v1H8zM4 12h1v1H4zm3 1h1v1H7zM5 6h1v1H5zm2 1h1v1H7zM8 5h1v1H8zm1 1h1v1H9zm1-1h1v1H9zm1 1h1v1H9zm1 1h1v1H9zm1 1h1v1H9z"/>
+</svg>

--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -1356,6 +1356,10 @@ export const folderIcons: FolderTheme[] = [
         folderNames: ['opencode'],
       },
       {
+        name: 'folder-forge',
+        folderNames: ['forge'],
+      },
+      {
         name: 'folder-input',
         folderNames: ['input', 'inputs', 'io', 'in'],
       },


### PR DESCRIPTION
Adds folder icon for .forge directory used by ForgeKit projects. ForgeKit is a Go CLI tool that generates production-ready REST APIs with hexagonal architecture. The .forge directory contains project metadata (forge.yaml, features.yaml). Icon based on official ForgeKit logo with orange accent color.

# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

## Contribution Guidelines

- [ ] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [ ] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
