### PR TITLE
feat: associate .xcode-version with swift icon

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -929,7 +929,12 @@ export const fileIcons: FileIcons = {
         'swiftmodule',
         'swiftsourceinfo',
       ],
-      fileNames: ['.swift-format', '.swift-version', '.swiftformat'],
+      fileNames: [
+        '.swift-format',
+        '.swift-version',
+        '.swiftformat',
+        '.xcode-version',
+      ],
     },
     { name: 'arduino', fileExtensions: ['ino'] },
     {


### PR DESCRIPTION
# Description

Associates `.xcode-version` with the existing `swift` icon, following the same pattern already used for `.swift-version`, `.ruby-version`, and `.node-version`.

`.xcode-version` is a version-pin dotfile convention for iOS/macOS projects (proposed and documented in [XcodesOrg/xcodes](https://github.com/XcodesOrg/xcodes/blob/main/XCODE_VERSION.md), and supported by tools like fastlane and xcode-install) that lets CI systems and IDEs automatically install/switch to the Xcode version a project needs. Since it lives in the same toolchain family as `.swift-version`, it currently falls back to the generic file icon instead of getting the Swift/Xcode icon it deserves.

No new SVG needed — this reuses the existing `swift` icon shape/color, just extends its `fileNames`.

- Verified locally via `npm run build` + `F5` (Run Extension) that `.xcode-version` renders with the Swift icon, matching `.swift-version` in the same folder.
- `npm run check` (icon conflict/availability checks) and `npm test` both pass.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
