### PR TITLE
fix: add missing `message` without `s` to `folder-messages`

### DIFF
--- a/src/core/icons/folderIcons.ts
+++ b/src/core/icons/folderIcons.ts
@@ -581,6 +581,7 @@ export const folderIcons: FolderTheme[] = [
       {
         name: 'folder-messages',
         folderNames: [
+          'message',
           'messages',
           'messaging',
           'forum',


### PR DESCRIPTION
# Description
The `folder-messages` icon includes `messages` but not `message` (without `s`), so I added it.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
