### PR TITLE
feat: add icon for aube

### DIFF
--- a/icons/aube.svg
+++ b/icons/aube.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="28" height="28" x="2" y="2" fill="#263238" rx="6"/><g fill="none" stroke="#fff8e1" stroke-linecap="round" stroke-width="2"><path d="M7 19h18"/><path d="M11 19a5 5 0 0 1 10 0"/></g></svg>

--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -3042,6 +3042,10 @@ export const fileIcons: FileIcons = {
       fileNames: ['pnpm-lock.yaml', 'pnpm-workspace.yaml', '.pnpmfile.cjs'],
     },
     {
+      name: 'aube',
+      fileNames: ['aube-lock.yaml', 'aube-workspace.yaml'],
+    },
+    {
       name: 'gridsome',
       fileNames: ['gridsome.config.js', 'gridsome.server.js'],
     },


### PR DESCRIPTION
# Description

<!-- Please describe in a short sentence or bullet points what changes you have made. -->

This PR adds a Material Design-compatible file icon based on the [official aube logo](https://github.com/jdx/aube/blob/main/assets/logo.svg) and associates it with [`aube-lock.yaml`](https://aube.jdx.dev/package-manager/lockfiles.html) and [`aube-workspace.yaml`](https://aube.jdx.dev/package-manager/workspaces.html).

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
