### PR TITLE
feat: add Rstack config file association

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -1678,6 +1678,7 @@ export const fileIcons: FileIcons = {
       name: 'rstack',
       fileNames: ['rslint.json', 'rslint.jsonc'],
       patterns: {
+        'rstack.config': FileNamePattern.Ecmascript,
         'rspack.config': FileNamePattern.Ecmascript,
         'rsbuild.config': FileNamePattern.Ecmascript,
         'rslib.config': FileNamePattern.Ecmascript,


### PR DESCRIPTION
# Description

Associate `rstack.config.*` files with the existing Rstack icon, following the [Rstack configuration guide](https://rstack.rs/guide/configuration).

This is a config-only follow-up to #3572; the icon artwork is unchanged.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
