### PR TITLE
feat: Add all supported file extensions for prisma.config

### DIFF
--- a/src/core/icons/fileIcons.ts
+++ b/src/core/icons/fileIcons.ts
@@ -2270,7 +2270,15 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'prisma',
-      fileNames: ['prisma.yml', 'prisma.config.ts'],
+      fileNames: [
+        'prisma.yml',
+        'prisma.config.ts',
+        'prisma.config.js',
+        'prisma.config.mts',
+        'prisma.config.mjs',
+        'prisma.config.cts',
+        'prisma.config.cjs',
+      ],
       fileExtensions: ['prisma'],
     },
     { name: 'razor', fileExtensions: ['cshtml', 'vbhtml', 'razor'] },


### PR DESCRIPTION
# Description

Prisma supports all these extensions [as stated in the docs](https://www.prisma.io/docs/orm/v7/reference/prisma-config-reference#supported-file-extensions): js, ts, mjs, cjs, mts, cts.

The icon has been updated to apply to all of them.

## Contribution Guidelines

- [x] By creating this pull request, I acknowledge that I have read the [Contribution Guidelines](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CONTRIBUTING.md) for this project
- [x] I have read the [Code Of Conduct](https://github.com/material-extensions/vscode-material-icon-theme/blob/main/CODE_OF_CONDUCT.md) and promise to abide by these rules
